### PR TITLE
change: deprecate .now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,11 @@ repos:
           ["arq>=0.25.0", "colorama>=0.4.6", "dill>=0.3.6", "types-colorama"]
 
   # docs
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
-    hooks:
-      - id: prettier
-        files: ^docs
+  # - repo: https://github.com/pre-commit/mirrors-prettier
+  #   rev: v2.7.1
+  #   hooks:
+  #     - id: prettier
+  #       files: ^docs
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2023-07-07
+
+### Changed
+
+- Deprecated `.now` in favor of direct calling (`func()`).
+
 ## [2.0.0] - 2023-05-05
 
 I discovered arq, and it does a lot of the same things I was hoping just-jobs would eventually support. Rather than remake the wheel, V2 is a complete rethinking and rewrite using arq as an engine.

--- a/docs/example.py
+++ b/docs/example.py
@@ -29,8 +29,7 @@ async def main() -> None:
     # create a redis broker using the Settings already defined
     async with Settings.create_pool() as pool:
         # run the_task right now and return the url
-        # even though this is a sync function, `.now` returns an awaitable
-        url = await sync_task.now("https://www.google.com")
+        url = sync_task("https://www.google.com")
         print(url)
 
         await pool.enqueue_job("async_task", "https://gianturl.net")

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=./just_jobs.html" />
-  </head>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./just_jobs.html"/>
+</head>
 </html>

--- a/docs/just_jobs.html
+++ b/docs/just_jobs.html
@@ -1,1410 +1,155 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="generator" content="pdoc 13.1.1" />
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="generator" content="pdoc 13.1.1"/>
     <title>just_jobs API documentation</title>
 
-    <style>
-      /*! * Bootstrap Reboot v5.0.0 (https://getbootstrap.com/) * Copyright 2011-2021 The Bootstrap Authors * Copyright 2011-2021 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */
-      *,
-      ::after,
-      ::before {
-        box-sizing: border-box;
-      }
-      @media (prefers-reduced-motion: no-preference) {
-        :root {
-          scroll-behavior: smooth;
-        }
-      }
-      body {
-        margin: 0;
-        font-family: system-ui, -apple-system, "Segoe UI", Roboto,
-          "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif,
-          "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-          "Noto Color Emoji";
-        font-size: 1rem;
-        font-weight: 400;
-        line-height: 1.5;
-        color: #212529;
-        background-color: #fff;
-        -webkit-text-size-adjust: 100%;
-        -webkit-tap-highlight-color: transparent;
-      }
-      hr {
-        margin: 1rem 0;
-        color: inherit;
-        background-color: currentColor;
-        border: 0;
-        opacity: 0.25;
-      }
-      hr:not([size]) {
-        height: 1px;
-      }
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6 {
-        margin-top: 0;
-        margin-bottom: 0.5rem;
-        font-weight: 500;
-        line-height: 1.2;
-      }
-      h1 {
-        font-size: calc(1.375rem + 1.5vw);
-      }
-      @media (min-width: 1200px) {
-        h1 {
-          font-size: 2.5rem;
-        }
-      }
-      h2 {
-        font-size: calc(1.325rem + 0.9vw);
-      }
-      @media (min-width: 1200px) {
-        h2 {
-          font-size: 2rem;
-        }
-      }
-      h3 {
-        font-size: calc(1.3rem + 0.6vw);
-      }
-      @media (min-width: 1200px) {
-        h3 {
-          font-size: 1.75rem;
-        }
-      }
-      h4 {
-        font-size: calc(1.275rem + 0.3vw);
-      }
-      @media (min-width: 1200px) {
-        h4 {
-          font-size: 1.5rem;
-        }
-      }
-      h5 {
-        font-size: 1.25rem;
-      }
-      h6 {
-        font-size: 1rem;
-      }
-      p {
-        margin-top: 0;
-        margin-bottom: 1rem;
-      }
-      abbr[data-bs-original-title],
-      abbr[title] {
-        -webkit-text-decoration: underline dotted;
-        text-decoration: underline dotted;
-        cursor: help;
-        -webkit-text-decoration-skip-ink: none;
-        text-decoration-skip-ink: none;
-      }
-      address {
-        margin-bottom: 1rem;
-        font-style: normal;
-        line-height: inherit;
-      }
-      ol,
-      ul {
-        padding-left: 2rem;
-      }
-      dl,
-      ol,
-      ul {
-        margin-top: 0;
-        margin-bottom: 1rem;
-      }
-      ol ol,
-      ol ul,
-      ul ol,
-      ul ul {
-        margin-bottom: 0;
-      }
-      dt {
-        font-weight: 700;
-      }
-      dd {
-        margin-bottom: 0.5rem;
-        margin-left: 0;
-      }
-      blockquote {
-        margin: 0 0 1rem;
-      }
-      b,
-      strong {
-        font-weight: bolder;
-      }
-      small {
-        font-size: 0.875em;
-      }
-      mark {
-        padding: 0.2em;
-        background-color: #fcf8e3;
-      }
-      sub,
-      sup {
-        position: relative;
-        font-size: 0.75em;
-        line-height: 0;
-        vertical-align: baseline;
-      }
-      sub {
-        bottom: -0.25em;
-      }
-      sup {
-        top: -0.5em;
-      }
-      a {
-        color: #0d6efd;
-        text-decoration: underline;
-      }
-      a:hover {
-        color: #0a58ca;
-      }
-      a:not([href]):not([class]),
-      a:not([href]):not([class]):hover {
-        color: inherit;
-        text-decoration: none;
-      }
-      code,
-      kbd,
-      pre,
-      samp {
-        font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-          "Courier New", monospace;
-        font-size: 1em;
-        direction: ltr;
-        unicode-bidi: bidi-override;
-      }
-      pre {
-        display: block;
-        margin-top: 0;
-        margin-bottom: 1rem;
-        overflow: auto;
-        font-size: 0.875em;
-      }
-      pre code {
-        font-size: inherit;
-        color: inherit;
-        word-break: normal;
-      }
-      code {
-        font-size: 0.875em;
-        color: #d63384;
-        word-wrap: break-word;
-      }
-      a > code {
-        color: inherit;
-      }
-      kbd {
-        padding: 0.2rem 0.4rem;
-        font-size: 0.875em;
-        color: #fff;
-        background-color: #212529;
-        border-radius: 0.2rem;
-      }
-      kbd kbd {
-        padding: 0;
-        font-size: 1em;
-        font-weight: 700;
-      }
-      figure {
-        margin: 0 0 1rem;
-      }
-      img,
-      svg {
-        vertical-align: middle;
-      }
-      table {
-        caption-side: bottom;
-        border-collapse: collapse;
-      }
-      caption {
-        padding-top: 0.5rem;
-        padding-bottom: 0.5rem;
-        color: #6c757d;
-        text-align: left;
-      }
-      th {
-        text-align: inherit;
-        text-align: -webkit-match-parent;
-      }
-      tbody,
-      td,
-      tfoot,
-      th,
-      thead,
-      tr {
-        border-color: inherit;
-        border-style: solid;
-        border-width: 0;
-      }
-      label {
-        display: inline-block;
-      }
-      button {
-        border-radius: 0;
-      }
-      button:focus:not(:focus-visible) {
-        outline: 0;
-      }
-      button,
-      input,
-      optgroup,
-      select,
-      textarea {
-        margin: 0;
-        font-family: inherit;
-        font-size: inherit;
-        line-height: inherit;
-      }
-      button,
-      select {
-        text-transform: none;
-      }
-      [role="button"] {
-        cursor: pointer;
-      }
-      select {
-        word-wrap: normal;
-      }
-      select:disabled {
-        opacity: 1;
-      }
-      [list]::-webkit-calendar-picker-indicator {
-        display: none;
-      }
-      [type="button"],
-      [type="reset"],
-      [type="submit"],
-      button {
-        -webkit-appearance: button;
-      }
-      [type="button"]:not(:disabled),
-      [type="reset"]:not(:disabled),
-      [type="submit"]:not(:disabled),
-      button:not(:disabled) {
-        cursor: pointer;
-      }
-      ::-moz-focus-inner {
-        padding: 0;
-        border-style: none;
-      }
-      textarea {
-        resize: vertical;
-      }
-      fieldset {
-        min-width: 0;
-        padding: 0;
-        margin: 0;
-        border: 0;
-      }
-      legend {
-        float: left;
-        width: 100%;
-        padding: 0;
-        margin-bottom: 0.5rem;
-        font-size: calc(1.275rem + 0.3vw);
-        line-height: inherit;
-      }
-      @media (min-width: 1200px) {
-        legend {
-          font-size: 1.5rem;
-        }
-      }
-      legend + * {
-        clear: left;
-      }
-      ::-webkit-datetime-edit-day-field,
-      ::-webkit-datetime-edit-fields-wrapper,
-      ::-webkit-datetime-edit-hour-field,
-      ::-webkit-datetime-edit-minute,
-      ::-webkit-datetime-edit-month-field,
-      ::-webkit-datetime-edit-text,
-      ::-webkit-datetime-edit-year-field {
-        padding: 0;
-      }
-      ::-webkit-inner-spin-button {
-        height: auto;
-      }
-      [type="search"] {
-        outline-offset: -2px;
-        -webkit-appearance: textfield;
-      }
-      ::-webkit-search-decoration {
-        -webkit-appearance: none;
-      }
-      ::-webkit-color-swatch-wrapper {
-        padding: 0;
-      }
-      ::file-selector-button {
-        font: inherit;
-      }
-      ::-webkit-file-upload-button {
-        font: inherit;
-        -webkit-appearance: button;
-      }
-      output {
-        display: inline-block;
-      }
-      iframe {
-        border: 0;
-      }
-      summary {
-        display: list-item;
-        cursor: pointer;
-      }
-      progress {
-        vertical-align: baseline;
-      }
-      [hidden] {
-        display: none !important;
-      }
-    </style>
-    <style>
-      /*! syntax-highlighting.css */
-      pre {
-        line-height: 125%;
-      }
-      span.linenos {
-        color: inherit;
-        background-color: transparent;
-        padding-left: 5px;
-        padding-right: 20px;
-      }
-      .pdoc-code .hll {
-        background-color: #ffffcc;
-      }
-      .pdoc-code {
-        background: #f8f8f8;
-      }
-      .pdoc-code .c {
-        color: #3d7b7b;
-        font-style: italic;
-      }
-      .pdoc-code .err {
-        border: 1px solid #ff0000;
-      }
-      .pdoc-code .k {
-        color: #008000;
-        font-weight: bold;
-      }
-      .pdoc-code .o {
-        color: #666666;
-      }
-      .pdoc-code .ch {
-        color: #3d7b7b;
-        font-style: italic;
-      }
-      .pdoc-code .cm {
-        color: #3d7b7b;
-        font-style: italic;
-      }
-      .pdoc-code .cp {
-        color: #9c6500;
-      }
-      .pdoc-code .cpf {
-        color: #3d7b7b;
-        font-style: italic;
-      }
-      .pdoc-code .c1 {
-        color: #3d7b7b;
-        font-style: italic;
-      }
-      .pdoc-code .cs {
-        color: #3d7b7b;
-        font-style: italic;
-      }
-      .pdoc-code .gd {
-        color: #a00000;
-      }
-      .pdoc-code .ge {
-        font-style: italic;
-      }
-      .pdoc-code .gr {
-        color: #e40000;
-      }
-      .pdoc-code .gh {
-        color: #000080;
-        font-weight: bold;
-      }
-      .pdoc-code .gi {
-        color: #008400;
-      }
-      .pdoc-code .go {
-        color: #717171;
-      }
-      .pdoc-code .gp {
-        color: #000080;
-        font-weight: bold;
-      }
-      .pdoc-code .gs {
-        font-weight: bold;
-      }
-      .pdoc-code .gu {
-        color: #800080;
-        font-weight: bold;
-      }
-      .pdoc-code .gt {
-        color: #0044dd;
-      }
-      .pdoc-code .kc {
-        color: #008000;
-        font-weight: bold;
-      }
-      .pdoc-code .kd {
-        color: #008000;
-        font-weight: bold;
-      }
-      .pdoc-code .kn {
-        color: #008000;
-        font-weight: bold;
-      }
-      .pdoc-code .kp {
-        color: #008000;
-      }
-      .pdoc-code .kr {
-        color: #008000;
-        font-weight: bold;
-      }
-      .pdoc-code .kt {
-        color: #b00040;
-      }
-      .pdoc-code .m {
-        color: #666666;
-      }
-      .pdoc-code .s {
-        color: #ba2121;
-      }
-      .pdoc-code .na {
-        color: #687822;
-      }
-      .pdoc-code .nb {
-        color: #008000;
-      }
-      .pdoc-code .nc {
-        color: #0000ff;
-        font-weight: bold;
-      }
-      .pdoc-code .no {
-        color: #880000;
-      }
-      .pdoc-code .nd {
-        color: #aa22ff;
-      }
-      .pdoc-code .ni {
-        color: #717171;
-        font-weight: bold;
-      }
-      .pdoc-code .ne {
-        color: #cb3f38;
-        font-weight: bold;
-      }
-      .pdoc-code .nf {
-        color: #0000ff;
-      }
-      .pdoc-code .nl {
-        color: #767600;
-      }
-      .pdoc-code .nn {
-        color: #0000ff;
-        font-weight: bold;
-      }
-      .pdoc-code .nt {
-        color: #008000;
-        font-weight: bold;
-      }
-      .pdoc-code .nv {
-        color: #19177c;
-      }
-      .pdoc-code .ow {
-        color: #aa22ff;
-        font-weight: bold;
-      }
-      .pdoc-code .w {
-        color: #bbbbbb;
-      }
-      .pdoc-code .mb {
-        color: #666666;
-      }
-      .pdoc-code .mf {
-        color: #666666;
-      }
-      .pdoc-code .mh {
-        color: #666666;
-      }
-      .pdoc-code .mi {
-        color: #666666;
-      }
-      .pdoc-code .mo {
-        color: #666666;
-      }
-      .pdoc-code .sa {
-        color: #ba2121;
-      }
-      .pdoc-code .sb {
-        color: #ba2121;
-      }
-      .pdoc-code .sc {
-        color: #ba2121;
-      }
-      .pdoc-code .dl {
-        color: #ba2121;
-      }
-      .pdoc-code .sd {
-        color: #ba2121;
-        font-style: italic;
-      }
-      .pdoc-code .s2 {
-        color: #ba2121;
-      }
-      .pdoc-code .se {
-        color: #aa5d1f;
-        font-weight: bold;
-      }
-      .pdoc-code .sh {
-        color: #ba2121;
-      }
-      .pdoc-code .si {
-        color: #a45a77;
-        font-weight: bold;
-      }
-      .pdoc-code .sx {
-        color: #008000;
-      }
-      .pdoc-code .sr {
-        color: #a45a77;
-      }
-      .pdoc-code .s1 {
-        color: #ba2121;
-      }
-      .pdoc-code .ss {
-        color: #19177c;
-      }
-      .pdoc-code .bp {
-        color: #008000;
-      }
-      .pdoc-code .fm {
-        color: #0000ff;
-      }
-      .pdoc-code .vc {
-        color: #19177c;
-      }
-      .pdoc-code .vg {
-        color: #19177c;
-      }
-      .pdoc-code .vi {
-        color: #19177c;
-      }
-      .pdoc-code .vm {
-        color: #19177c;
-      }
-      .pdoc-code .il {
-        color: #666666;
-      }
-    </style>
-    <style>
-      /*! theme.css */
-      :root {
-        --pdoc-background: #fff;
-      }
-      .pdoc {
-        --text: #212529;
-        --muted: #6c757d;
-        --link: #3660a5;
-        --link-hover: #1659c5;
-        --code: #f8f8f8;
-        --active: #fff598;
-        --accent: #eee;
-        --accent2: #c1c1c1;
-        --nav-hover: rgba(255, 255, 255, 0.5);
-        --name: #0066bb;
-        --def: #008800;
-        --annotation: #007020;
-      }
-    </style>
-    <style>
-      /*! layout.css */
-      html,
-      body {
-        width: 100%;
-        height: 100%;
-      }
-      html,
-      main {
-        scroll-behavior: smooth;
-      }
-      body {
-        background-color: var(--pdoc-background);
-      }
-      @media (max-width: 769px) {
-        #navtoggle {
-          cursor: pointer;
-          position: absolute;
-          width: 50px;
-          height: 40px;
-          top: 1rem;
-          right: 1rem;
-          border-color: var(--text);
-          color: var(--text);
-          display: flex;
-          opacity: 0.8;
-          z-index: 999;
-        }
-        #navtoggle:hover {
-          opacity: 1;
-        }
-        #togglestate + div {
-          display: none;
-        }
-        #togglestate:checked + div {
-          display: inherit;
-        }
-        main,
-        header {
-          padding: 2rem 3vw;
-        }
-        header + main {
-          margin-top: -3rem;
-        }
-        .git-button {
-          display: none !important;
-        }
-        nav input[type="search"] {
-          max-width: 77%;
-        }
-        nav input[type="search"]:first-child {
-          margin-top: -6px;
-        }
-        nav input[type="search"]:valid ~ * {
-          display: none !important;
-        }
-      }
-      @media (min-width: 770px) {
-        :root {
-          --sidebar-width: clamp(12.5rem, 28vw, 22rem);
-        }
-        nav {
-          position: fixed;
-          overflow: auto;
-          height: 100vh;
-          width: var(--sidebar-width);
-        }
-        main,
-        header {
-          padding: 3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);
-          width: calc(54rem + var(--sidebar-width));
-          max-width: 100%;
-        }
-        header + main {
-          margin-top: -4rem;
-        }
-        #navtoggle {
-          display: none;
-        }
-      }
-      #togglestate {
-        position: absolute;
-        height: 0;
-        opacity: 0;
-      }
-      nav.pdoc {
-        --pad: clamp(0.5rem, 2vw, 1.75rem);
-        --indent: 1.5rem;
-        background-color: var(--accent);
-        border-right: 1px solid var(--accent2);
-        box-shadow: 0 0 20px rgba(50, 50, 50, 0.2) inset;
-        padding: 0 0 0 var(--pad);
-        overflow-wrap: anywhere;
-        scrollbar-width: thin;
-        scrollbar-color: var(--accent2) transparent;
-      }
-      nav.pdoc::-webkit-scrollbar {
-        width: 0.4rem;
-      }
-      nav.pdoc::-webkit-scrollbar-thumb {
-        background-color: var(--accent2);
-      }
-      nav.pdoc > div {
-        padding: var(--pad) 0;
-      }
-      nav.pdoc .module-list-button {
-        display: inline-flex;
-        align-items: center;
-        color: var(--text);
-        border-color: var(--muted);
-        margin-bottom: 1rem;
-      }
-      nav.pdoc .module-list-button:hover {
-        border-color: var(--text);
-      }
-      nav.pdoc input[type="search"] {
-        display: block;
-        outline-offset: 0;
-        width: calc(100% - var(--pad));
-      }
-      nav.pdoc .logo {
-        max-width: calc(100% - var(--pad));
-        max-height: 35vh;
-        display: block;
-        margin: 0 auto 1rem;
-        transform: translate(calc(-0.5 * var(--pad)), 0);
-      }
-      nav.pdoc ul {
-        list-style: none;
-        padding-left: 0;
-      }
-      nav.pdoc > div > ul {
-        margin-left: calc(0px - var(--pad));
-      }
-      nav.pdoc li a {
-        padding: 0.2rem 0 0.2rem calc(var(--pad) + var(--indent));
-      }
-      nav.pdoc > div > ul > li > a {
-        padding-left: var(--pad);
-      }
-      nav.pdoc li {
-        transition: all 100ms;
-      }
-      nav.pdoc li:hover {
-        background-color: var(--nav-hover);
-      }
-      nav.pdoc a,
-      nav.pdoc a:hover {
-        color: var(--text);
-      }
-      nav.pdoc a {
-        display: block;
-      }
-      nav.pdoc > h2:first-of-type {
-        margin-top: 1.5rem;
-      }
-      nav.pdoc .class:before {
-        content: "class ";
-        color: var(--muted);
-      }
-      nav.pdoc .function:after {
-        content: "()";
-        color: var(--muted);
-      }
-      nav.pdoc footer:before {
-        content: "";
-        display: block;
-        width: calc(100% - var(--pad));
-        border-top: solid var(--accent2) 1px;
-        margin-top: 1.5rem;
-        padding-top: 0.5rem;
-      }
-      nav.pdoc footer {
-        font-size: small;
-      }
-    </style>
-    <style>
-      /*! content.css */
-      .pdoc {
-        color: var(--text);
-        box-sizing: border-box;
-        line-height: 1.5;
-        background: none;
-      }
-      .pdoc .pdoc-button {
-        cursor: pointer;
-        display: inline-block;
-        border: solid black 1px;
-        border-radius: 2px;
-        font-size: 0.75rem;
-        padding: calc(0.5em - 1px) 1em;
-        transition: 100ms all;
-      }
-      .pdoc .pdoc-alert {
-        padding: 1rem 1rem 1rem calc(1.5rem + 24px);
-        border: 1px solid transparent;
-        border-radius: 0.25rem;
-        background-repeat: no-repeat;
-        background-position: 1rem center;
-        margin-bottom: 1rem;
-      }
-      .pdoc .pdoc-alert > *:last-child {
-        margin-bottom: 0;
-      }
-      .pdoc .pdoc-alert-note {
-        color: #084298;
-        background-color: #cfe2ff;
-        border-color: #b6d4fe;
-        background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23084298%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8%2016A8%208%200%201%200%208%200a8%208%200%200%200%200%2016zm.93-9.412-1%204.705c-.07.34.029.533.304.533.194%200%20.487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703%200-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381%202.29-.287zM8%205.5a1%201%200%201%201%200-2%201%201%200%200%201%200%202z%22/%3E%3C/svg%3E");
-      }
-      .pdoc .pdoc-alert-warning {
-        color: #664d03;
-        background-color: #fff3cd;
-        border-color: #ffecb5;
-        background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23664d03%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8.982%201.566a1.13%201.13%200%200%200-1.96%200L.165%2013.233c-.457.778.091%201.767.98%201.767h13.713c.889%200%201.438-.99.98-1.767L8.982%201.566zM8%205c.535%200%20.954.462.9.995l-.35%203.507a.552.552%200%200%201-1.1%200L7.1%205.995A.905.905%200%200%201%208%205zm.002%206a1%201%200%201%201%200%202%201%201%200%200%201%200-2z%22/%3E%3C/svg%3E");
-      }
-      .pdoc .pdoc-alert-danger {
-        color: #842029;
-        background-color: #f8d7da;
-        border-color: #f5c2c7;
-        background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23842029%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M5.52.359A.5.5%200%200%201%206%200h4a.5.5%200%200%201%20.474.658L8.694%206H12.5a.5.5%200%200%201%20.395.807l-7%209a.5.5%200%200%201-.873-.454L6.823%209.5H3.5a.5.5%200%200%201-.48-.641l2.5-8.5z%22/%3E%3C/svg%3E");
-      }
-      .pdoc .visually-hidden {
-        position: absolute !important;
-        width: 1px !important;
-        height: 1px !important;
-        padding: 0 !important;
-        margin: -1px !important;
-        overflow: hidden !important;
-        clip: rect(0, 0, 0, 0) !important;
-        white-space: nowrap !important;
-        border: 0 !important;
-      }
-      .pdoc h1,
-      .pdoc h2,
-      .pdoc h3 {
-        font-weight: 300;
-        margin: 0.3em 0;
-        padding: 0.2em 0;
-      }
-      .pdoc > section:not(.module-info) h1 {
-        font-size: 1.5rem;
-        font-weight: 500;
-      }
-      .pdoc > section:not(.module-info) h2 {
-        font-size: 1.4rem;
-        font-weight: 500;
-      }
-      .pdoc > section:not(.module-info) h3 {
-        font-size: 1.3rem;
-        font-weight: 500;
-      }
-      .pdoc > section:not(.module-info) h4 {
-        font-size: 1.2rem;
-      }
-      .pdoc > section:not(.module-info) h5 {
-        font-size: 1.1rem;
-      }
-      .pdoc a {
-        text-decoration: none;
-        color: var(--link);
-      }
-      .pdoc a:hover {
-        color: var(--link-hover);
-      }
-      .pdoc blockquote {
-        margin-left: 2rem;
-      }
-      .pdoc pre {
-        border-top: 1px solid var(--accent2);
-        border-bottom: 1px solid var(--accent2);
-        margin-top: 0;
-        margin-bottom: 1em;
-        padding: 0.5rem 0 0.5rem 0.5rem;
-        overflow-x: auto;
-        background-color: var(--code);
-      }
-      .pdoc code {
-        color: var(--text);
-        padding: 0.2em 0.4em;
-        margin: 0;
-        font-size: 85%;
-        background-color: var(--code);
-        border-radius: 6px;
-      }
-      .pdoc a > code {
-        color: inherit;
-      }
-      .pdoc pre > code {
-        display: inline-block;
-        font-size: inherit;
-        background: none;
-        border: none;
-        padding: 0;
-      }
-      .pdoc > section:not(.module-info) {
-        margin-bottom: 1.5rem;
-      }
-      .pdoc .modulename {
-        margin-top: 0;
-        font-weight: bold;
-      }
-      .pdoc .modulename a {
-        color: var(--link);
-        transition: 100ms all;
-      }
-      .pdoc .git-button {
-        float: right;
-        border: solid var(--link) 1px;
-      }
-      .pdoc .git-button:hover {
-        background-color: var(--link);
-        color: var(--pdoc-background);
-      }
-      .view-source-toggle-state,
-      .view-source-toggle-state ~ .pdoc-code {
-        display: none;
-      }
-      .view-source-toggle-state:checked ~ .pdoc-code {
-        display: block;
-      }
-      .view-source-button {
-        display: inline-block;
-        float: right;
-        font-size: 0.75rem;
-        line-height: 1.5rem;
-        color: var(--muted);
-        padding: 0 0.4rem 0 1.3rem;
-        cursor: pointer;
-        text-indent: -2px;
-      }
-      .view-source-button > span {
-        visibility: hidden;
-      }
-      .module-info .view-source-button {
-        float: none;
-        display: flex;
-        justify-content: flex-end;
-        margin: -1.2rem 0.4rem -0.2rem 0;
-      }
-      .view-source-button::before {
-        position: absolute;
-        content: "View Source";
-        display: list-item;
-        list-style-type: disclosure-closed;
-      }
-      .view-source-toggle-state:checked ~ .attr .view-source-button::before,
-      .view-source-toggle-state:checked ~ .view-source-button::before {
-        list-style-type: disclosure-open;
-      }
-      .pdoc .docstring {
-        margin-bottom: 1.5rem;
-      }
-      .pdoc section:not(.module-info) .docstring {
-        margin-left: clamp(0rem, 5vw - 2rem, 1rem);
-      }
-      .pdoc .docstring .pdoc-code {
-        margin-left: 1em;
-        margin-right: 1em;
-      }
-      .pdoc h1:target,
-      .pdoc h2:target,
-      .pdoc h3:target,
-      .pdoc h4:target,
-      .pdoc h5:target,
-      .pdoc h6:target,
-      .pdoc .pdoc-code > pre > span:target {
-        background-color: var(--active);
-        box-shadow: -1rem 0 0 0 var(--active);
-      }
-      .pdoc .pdoc-code > pre > span:target {
-        display: block;
-      }
-      .pdoc div:target > .attr,
-      .pdoc section:target > .attr,
-      .pdoc dd:target > a {
-        background-color: var(--active);
-      }
-      .pdoc * {
-        scroll-margin: 2rem;
-      }
-      .pdoc .pdoc-code .linenos {
-        user-select: none;
-      }
-      .pdoc .attr:hover {
-        filter: contrast(0.95);
-      }
-      .pdoc section,
-      .pdoc .classattr {
-        position: relative;
-      }
-      .pdoc .headerlink {
-        --width: clamp(1rem, 3vw, 2rem);
-        position: absolute;
-        top: 0;
-        left: calc(0rem - var(--width));
-        transition: all 100ms ease-in-out;
-        opacity: 0;
-      }
-      .pdoc .headerlink::before {
-        content: "#";
-        display: block;
-        text-align: center;
-        width: var(--width);
-        height: 2.3rem;
-        line-height: 2.3rem;
-        font-size: 1.5rem;
-      }
-      .pdoc .attr:hover ~ .headerlink,
-      .pdoc *:target > .headerlink,
-      .pdoc .headerlink:hover {
-        opacity: 1;
-      }
-      .pdoc .attr {
-        display: block;
-        margin: 0.5rem 0 0.5rem;
-        padding: 0.4rem 0.4rem 0.4rem 1rem;
-        background-color: var(--accent);
-        overflow-x: auto;
-      }
-      .pdoc .classattr {
-        margin-left: 2rem;
-      }
-      .pdoc .name {
-        color: var(--name);
-        font-weight: bold;
-      }
-      .pdoc .def {
-        color: var(--def);
-        font-weight: bold;
-      }
-      .pdoc .signature {
-        background-color: transparent;
-      }
-      .pdoc .param,
-      .pdoc .return-annotation {
-        white-space: pre;
-      }
-      .pdoc .signature.multiline .param {
-        display: block;
-      }
-      .pdoc .signature.condensed .param {
-        display: inline-block;
-      }
-      .pdoc .annotation {
-        color: var(--annotation);
-      }
-      .pdoc .view-value-toggle-state,
-      .pdoc .view-value-toggle-state ~ .default_value {
-        display: none;
-      }
-      .pdoc .view-value-toggle-state:checked ~ .default_value {
-        display: inherit;
-      }
-      .pdoc .view-value-button {
-        font-size: 0.5rem;
-        vertical-align: middle;
-        border-style: dashed;
-        margin-top: -0.1rem;
-      }
-      .pdoc .view-value-button:hover {
-        background: white;
-      }
-      .pdoc .view-value-button::before {
-        content: "show";
-        text-align: center;
-        width: 2.2em;
-        display: inline-block;
-      }
-      .pdoc .view-value-toggle-state:checked ~ .view-value-button::before {
-        content: "hide";
-      }
-      .pdoc .inherited {
-        margin-left: 2rem;
-      }
-      .pdoc .inherited dt {
-        font-weight: 700;
-      }
-      .pdoc .inherited dt,
-      .pdoc .inherited dd {
-        display: inline;
-        margin-left: 0;
-        margin-bottom: 0.5rem;
-      }
-      .pdoc .inherited dd:not(:last-child):after {
-        content: ", ";
-      }
-      .pdoc .inherited .class:before {
-        content: "class ";
-      }
-      .pdoc .inherited .function a:after {
-        content: "()";
-      }
-      .pdoc .search-result .docstring {
-        overflow: auto;
-        max-height: 25vh;
-      }
-      .pdoc .search-result.focused > .attr {
-        background-color: var(--active);
-      }
-      .pdoc .attribution {
-        margin-top: 2rem;
-        display: block;
-        opacity: 0.5;
-        transition: all 200ms;
-        filter: grayscale(100%);
-      }
-      .pdoc .attribution:hover {
-        opacity: 1;
-        filter: grayscale(0%);
-      }
-      .pdoc .attribution img {
-        margin-left: 5px;
-        height: 35px;
-        vertical-align: middle;
-        width: 70px;
-        transition: all 200ms;
-      }
-      .pdoc table {
-        display: block;
-        width: max-content;
-        max-width: 100%;
-        overflow: auto;
-        margin-bottom: 1rem;
-      }
-      .pdoc table th {
-        font-weight: 600;
-      }
-      .pdoc table th,
-      .pdoc table td {
-        padding: 6px 13px;
-        border: 1px solid var(--accent2);
-      }
-    </style>
-    <style>
-      /*! custom.css */
-    </style>
-  </head>
-  <body>
+    <style>/*! * Bootstrap Reboot v5.0.0 (https://getbootstrap.com/) * Copyright 2011-2021 The Bootstrap Authors * Copyright 2011-2021 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus:not(:focus-visible){outline:0}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}select:disabled{opacity:1}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
+    <style>/*! syntax-highlighting.css */pre{line-height:125%;}span.linenos{color:inherit; background-color:transparent; padding-left:5px; padding-right:20px;}.pdoc-code .hll{background-color:#ffffcc}.pdoc-code{background:#f8f8f8;}.pdoc-code .c{color:#3D7B7B; font-style:italic}.pdoc-code .err{border:1px solid #FF0000}.pdoc-code .k{color:#008000; font-weight:bold}.pdoc-code .o{color:#666666}.pdoc-code .ch{color:#3D7B7B; font-style:italic}.pdoc-code .cm{color:#3D7B7B; font-style:italic}.pdoc-code .cp{color:#9C6500}.pdoc-code .cpf{color:#3D7B7B; font-style:italic}.pdoc-code .c1{color:#3D7B7B; font-style:italic}.pdoc-code .cs{color:#3D7B7B; font-style:italic}.pdoc-code .gd{color:#A00000}.pdoc-code .ge{font-style:italic}.pdoc-code .gr{color:#E40000}.pdoc-code .gh{color:#000080; font-weight:bold}.pdoc-code .gi{color:#008400}.pdoc-code .go{color:#717171}.pdoc-code .gp{color:#000080; font-weight:bold}.pdoc-code .gs{font-weight:bold}.pdoc-code .gu{color:#800080; font-weight:bold}.pdoc-code .gt{color:#0044DD}.pdoc-code .kc{color:#008000; font-weight:bold}.pdoc-code .kd{color:#008000; font-weight:bold}.pdoc-code .kn{color:#008000; font-weight:bold}.pdoc-code .kp{color:#008000}.pdoc-code .kr{color:#008000; font-weight:bold}.pdoc-code .kt{color:#B00040}.pdoc-code .m{color:#666666}.pdoc-code .s{color:#BA2121}.pdoc-code .na{color:#687822}.pdoc-code .nb{color:#008000}.pdoc-code .nc{color:#0000FF; font-weight:bold}.pdoc-code .no{color:#880000}.pdoc-code .nd{color:#AA22FF}.pdoc-code .ni{color:#717171; font-weight:bold}.pdoc-code .ne{color:#CB3F38; font-weight:bold}.pdoc-code .nf{color:#0000FF}.pdoc-code .nl{color:#767600}.pdoc-code .nn{color:#0000FF; font-weight:bold}.pdoc-code .nt{color:#008000; font-weight:bold}.pdoc-code .nv{color:#19177C}.pdoc-code .ow{color:#AA22FF; font-weight:bold}.pdoc-code .w{color:#bbbbbb}.pdoc-code .mb{color:#666666}.pdoc-code .mf{color:#666666}.pdoc-code .mh{color:#666666}.pdoc-code .mi{color:#666666}.pdoc-code .mo{color:#666666}.pdoc-code .sa{color:#BA2121}.pdoc-code .sb{color:#BA2121}.pdoc-code .sc{color:#BA2121}.pdoc-code .dl{color:#BA2121}.pdoc-code .sd{color:#BA2121; font-style:italic}.pdoc-code .s2{color:#BA2121}.pdoc-code .se{color:#AA5D1F; font-weight:bold}.pdoc-code .sh{color:#BA2121}.pdoc-code .si{color:#A45A77; font-weight:bold}.pdoc-code .sx{color:#008000}.pdoc-code .sr{color:#A45A77}.pdoc-code .s1{color:#BA2121}.pdoc-code .ss{color:#19177C}.pdoc-code .bp{color:#008000}.pdoc-code .fm{color:#0000FF}.pdoc-code .vc{color:#19177C}.pdoc-code .vg{color:#19177C}.pdoc-code .vi{color:#19177C}.pdoc-code .vm{color:#19177C}.pdoc-code .il{color:#666666}</style>
+    <style>/*! theme.css */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f8f8f8;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}</style>
+    <style>/*! layout.css */html, body{width:100%;height:100%;}html, main{scroll-behavior:smooth;}body{background-color:var(--pdoc-background);}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;z-index:999;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main, header{padding:2rem 3vw;}header + main{margin-top:-3rem;}.git-button{display:none !important;}nav input[type="search"]{max-width:77%;}nav input[type="search"]:first-child{margin-top:-6px;}nav input[type="search"]:valid ~ *{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main, header{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}header + main{margin-top:-4rem;}#navtoggle{display:none;}}#togglestate{position:absolute;height:0;opacity:0;}nav.pdoc{--pad:clamp(0.5rem, 2vw, 1.75rem);--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc input[type=search]{display:block;outline-offset:0;width:calc(100% - var(--pad));}nav.pdoc .logo{max-width:calc(100% - var(--pad));max-height:35vh;display:block;margin:0 auto 1rem;transform:translate(calc(-.5 * var(--pad)), 0);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc > div > ul{margin-left:calc(0px - var(--pad));}nav.pdoc li a{padding:.2rem 0 .2rem calc(var(--pad) + var(--indent));}nav.pdoc > div > ul > li > a{padding-left:var(--pad);}nav.pdoc li{transition:all 100ms;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}nav.pdoc footer:before{content:"";display:block;width:calc(100% - var(--pad));border-top:solid var(--accent2) 1px;margin-top:1.5rem;padding-top:.5rem;}nav.pdoc footer{font-size:small;}</style>
+    <style>/*! content.css */.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{cursor:pointer;display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .pdoc-alert{padding:1rem 1rem 1rem calc(1.5rem + 24px);border:1px solid transparent;border-radius:.25rem;background-repeat:no-repeat;background-position:1rem center;margin-bottom:1rem;}.pdoc .pdoc-alert > *:last-child{margin-bottom:0;}.pdoc .pdoc-alert-note {color:#084298;background-color:#cfe2ff;border-color:#b6d4fe;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23084298%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8%2016A8%208%200%201%200%208%200a8%208%200%200%200%200%2016zm.93-9.412-1%204.705c-.07.34.029.533.304.533.194%200%20.487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703%200-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381%202.29-.287zM8%205.5a1%201%200%201%201%200-2%201%201%200%200%201%200%202z%22/%3E%3C/svg%3E");}.pdoc .pdoc-alert-warning{color:#664d03;background-color:#fff3cd;border-color:#ffecb5;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23664d03%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8.982%201.566a1.13%201.13%200%200%200-1.96%200L.165%2013.233c-.457.778.091%201.767.98%201.767h13.713c.889%200%201.438-.99.98-1.767L8.982%201.566zM8%205c.535%200%20.954.462.9.995l-.35%203.507a.552.552%200%200%201-1.1%200L7.1%205.995A.905.905%200%200%201%208%205zm.002%206a1%201%200%201%201%200%202%201%201%200%200%201%200-2z%22/%3E%3C/svg%3E");}.pdoc .pdoc-alert-danger{color:#842029;background-color:#f8d7da;border-color:#f5c2c7;background-image:url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2224%22%20height%3D%2224%22%20fill%3D%22%23842029%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M5.52.359A.5.5%200%200%201%206%200h4a.5.5%200%200%201%20.474.658L8.694%206H12.5a.5.5%200%200%201%20.395.807l-7%209a.5.5%200%200%201-.873-.454L6.823%209.5H3.5a.5.5%200%200%201-.48-.641l2.5-8.5z%22/%3E%3C/svg%3E");}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc > section:not(.module-info) h1{font-size:1.5rem;font-weight:500;}.pdoc > section:not(.module-info) h2{font-size:1.4rem;font-weight:500;}.pdoc > section:not(.module-info) h3{font-size:1.3rem;font-weight:500;}.pdoc > section:not(.module-info) h4{font-size:1.2rem;}.pdoc > section:not(.module-info) h5{font-size:1.1rem;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-top:0;margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;background-color:var(--code);}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc > section:not(.module-info){margin-bottom:1.5rem;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.view-source-toggle-state,.view-source-toggle-state ~ .pdoc-code{display:none;}.view-source-toggle-state:checked ~ .pdoc-code{display:block;}.view-source-button{display:inline-block;float:right;font-size:.75rem;line-height:1.5rem;color:var(--muted);padding:0 .4rem 0 1.3rem;cursor:pointer;text-indent:-2px;}.view-source-button > span{visibility:hidden;}.module-info .view-source-button{float:none;display:flex;justify-content:flex-end;margin:-1.2rem .4rem -.2rem 0;}.view-source-button::before{position:absolute;content:"View Source";display:list-item;list-style-type:disclosure-closed;}.view-source-toggle-state:checked ~ .attr .view-source-button::before,.view-source-toggle-state:checked ~ .view-source-button::before{list-style-type:disclosure-open;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc section:not(.module-info) .docstring{margin-left:clamp(0rem, 5vw - 2rem, 1rem);}.pdoc .docstring .pdoc-code{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target,.pdoc .pdoc-code > pre > span:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc .pdoc-code > pre > span:target{display:block;}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc *{scroll-margin:2rem;}.pdoc .pdoc-code .linenos{user-select:none;}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc section, .pdoc .classattr{position:relative;}.pdoc .headerlink{--width:clamp(1rem, 3vw, 2rem);position:absolute;top:0;left:calc(0rem - var(--width));transition:all 100ms ease-in-out;opacity:0;}.pdoc .headerlink::before{content:"#";display:block;text-align:center;width:var(--width);height:2.3rem;line-height:2.3rem;font-size:1.5rem;}.pdoc .attr:hover ~ .headerlink,.pdoc *:target > .headerlink,.pdoc .headerlink:hover{opacity:1;}.pdoc .attr{display:block;margin:.5rem 0 .5rem;padding:.4rem .4rem .4rem 1rem;background-color:var(--accent);overflow-x:auto;}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{background-color:transparent;}.pdoc .param, .pdoc .return-annotation{white-space:pre;}.pdoc .signature.multiline .param{display:block;}.pdoc .signature.condensed .param{display:inline-block;}.pdoc .annotation{color:var(--annotation);}.pdoc .view-value-toggle-state,.pdoc .view-value-toggle-state ~ .default_value{display:none;}.pdoc .view-value-toggle-state:checked ~ .default_value{display:inherit;}.pdoc .view-value-button{font-size:.5rem;vertical-align:middle;border-style:dashed;margin-top:-0.1rem;}.pdoc .view-value-button:hover{background:white;}.pdoc .view-value-button::before{content:"show";text-align:center;width:2.2em;display:inline-block;}.pdoc .view-value-toggle-state:checked ~ .view-value-button::before{content:"hide";}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .search-result .docstring{overflow:auto;max-height:25vh;}.pdoc .search-result.focused > .attr{background-color:var(--active);}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}.pdoc table{display:block;width:max-content;max-width:100%;overflow:auto;margin-bottom:1rem;}.pdoc table th{font-weight:600;}.pdoc table th, .pdoc table td{padding:6px 13px;border:1px solid var(--accent2);}</style>
+    <style>/*! custom.css */</style></head>
+<body>
     <nav class="pdoc">
-      <label id="navtoggle" for="togglestate" class="pdoc-button"
-        ><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
-          <path
-            stroke-linecap="round"
-            stroke="currentColor"
-            stroke-miterlimit="10"
-            stroke-width="2"
-            d="M4 7h22M4 15h22M4 23h22"
-          /></svg
-      ></label>
-      <input
-        id="togglestate"
-        type="checkbox"
-        aria-hidden="true"
-        tabindex="-1"
-      />
-      <div>
-        <h2>Contents</h2>
-        <ul>
-          <li>
-            <a href="#just-jobs">just-jobs</a>
+        <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
+        <input id="togglestate" type="checkbox" aria-hidden="true" tabindex="-1">
+        <div>
+
+
+            <h2>Contents</h2>
             <ul>
-              <li><a href="#features">Features</a></li>
-              <li><a href="#usage">Usage</a></li>
-              <li><a href="#caveats">Caveats</a></li>
-              <li><a href="#example">Example</a></li>
-              <li><a href="#license">License</a></li>
-            </ul>
-          </li>
-        </ul>
+  <li><a href="#just-jobs">just-jobs</a>
+  <ul>
+    <li><a href="#features">Features</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#caveats">Caveats</a></li>
+    <li><a href="#example">Example</a></li>
+    <li><a href="#license">License</a></li>
+  </ul></li>
+</ul>
 
-        <h2>API Documentation</h2>
-        <ul class="memberlist">
-          <li>
-            <a class="function" href="#job">job</a>
-          </li>
-          <li>
-            <a class="class" href="#JobType">JobType</a>
-            <ul class="memberlist">
-              <li>
-                <a class="variable" href="#JobType.IO_BOUND">IO_BOUND</a>
-              </li>
-              <li>
-                <a class="variable" href="#JobType.CPU_BOUND">CPU_BOUND</a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a class="class" href="#BaseSettings">BaseSettings</a>
-            <ul class="memberlist">
-              <li>
-                <a class="function" href="#BaseSettings.on_startup"
-                  >on_startup</a
-                >
-              </li>
-              <li>
-                <a class="function" href="#BaseSettings.on_shutdown"
-                  >on_shutdown</a
-                >
-              </li>
-              <li>
-                <a class="function" href="#BaseSettings.job_serializer"
-                  >job_serializer</a
-                >
-              </li>
-              <li>
-                <a class="function" href="#BaseSettings.job_deserializer"
-                  >job_deserializer</a
-                >
-              </li>
-              <li>
-                <a class="function" href="#BaseSettings.create_pool"
-                  >create_pool</a
-                >
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a class="variable" href="#Context">Context</a>
-          </li>
-        </ul>
 
-        <a
-          class="attribution"
-          title="pdoc: Python API documentation generator"
-          href="https://pdoc.dev"
-          target="_blank"
-        >
-          built with <span class="visually-hidden">pdoc</span
-          ><img
-            alt="pdoc logo"
-            src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"
-          />
+
+            <h2>API Documentation</h2>
+                <ul class="memberlist">
+            <li>
+                    <a class="function" href="#job">job</a>
+            </li>
+            <li>
+                    <a class="class" href="#JobType">JobType</a>
+                            <ul class="memberlist">
+                        <li>
+                                <a class="variable" href="#JobType.IO_BOUND">IO_BOUND</a>
+                        </li>
+                        <li>
+                                <a class="variable" href="#JobType.CPU_BOUND">CPU_BOUND</a>
+                        </li>
+                </ul>
+
+            </li>
+            <li>
+                    <a class="class" href="#BaseSettings">BaseSettings</a>
+                            <ul class="memberlist">
+                        <li>
+                                <a class="function" href="#BaseSettings.on_startup">on_startup</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#BaseSettings.on_shutdown">on_shutdown</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#BaseSettings.job_serializer">job_serializer</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#BaseSettings.job_deserializer">job_deserializer</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#BaseSettings.create_pool">create_pool</a>
+                        </li>
+                </ul>
+
+            </li>
+            <li>
+                    <a class="variable" href="#Context">Context</a>
+            </li>
+    </ul>
+
+
+
+        <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev" target="_blank">
+            built with <span class="visually-hidden">pdoc</span><img
+                alt="pdoc logo"
+                src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
         </a>
-      </div>
+</div>
     </nav>
     <main class="pdoc">
-      <section class="module-info">
-        <h1 class="modulename">just_jobs</h1>
+            <section class="module-info">
+                    <h1 class="modulename">
+just_jobs    </h1>
 
-        <div class="docstring">
-          <h1 id="just-jobs">just-jobs</h1>
+                        <div class="docstring"><h1 id="just-jobs">just-jobs</h1>
 
-          <p>
-            <img
-              src="https://img.shields.io/github/actions/workflow/status/thearchitector/just-jobs/ci.yaml?label=tests&style=flat-square"
-              alt="GitHub Workflow Status"
-            />
-            <img
-              src="https://img.shields.io/pypi/dw/just-jobs?style=flat-square"
-              alt="PyPI - Downloads"
-            />
-            <img
-              src="https://img.shields.io/github/license/thearchitector/just-jobs?style=flat-square"
-              alt="GitHub"
-            />
-            <a
-              href="https://ecologi.com/eliasgabriel?r=6128126916bfab8bd051026c"
-              ><img
-                src="https://img.shields.io/badge/Treeware-%F0%9F%8C%B3-lightgreen?style=flat-square"
-                alt="Buy a tree"
-            /></a>
-          </p>
+<p><img src="https://img.shields.io/github/actions/workflow/status/thearchitector/just-jobs/ci.yaml?label=tests&style=flat-square" alt="GitHub Workflow Status" />
+<img src="https://img.shields.io/pypi/dw/just-jobs?style=flat-square" alt="PyPI - Downloads" />
+<img src="https://img.shields.io/github/license/thearchitector/just-jobs?style=flat-square" alt="GitHub" />
+<a href="https://ecologi.com/eliasgabriel?r=6128126916bfab8bd051026c"><img src="https://img.shields.io/badge/Treeware-%F0%9F%8C%B3-lightgreen?style=flat-square" alt="Buy a tree" /></a></p>
 
-          <p>
-            A friendly and lightweight wrapper for
-            <a href="https://arq-docs.helpmanual.io">arq</a>. just-jobs provides
-            a simple interface on top of arq that implements additional
-            functionality like synchronous job types (IO-bound vs. CPU-bound)
-            and signed and secure task serialization.
-          </p>
+<p>A friendly and lightweight wrapper for <a href="https://arq-docs.helpmanual.io">arq</a>. just-jobs provides a simple interface on top of arq that implements additional functionality like synchronous job types (IO-bound vs. CPU-bound) and signed and secure task serialization.</p>
 
-          <p>
-            Documentation:
-            <a href="https://justjobs.thearchitector.dev"
-              >https://justjobs.thearchitector.dev</a
-            >.
-          </p>
+<p>Documentation: <a href="https://justjobs.thearchitector.dev">https://justjobs.thearchitector.dev</a>.</p>
 
-          <p>Tested support on Python 3.7, 3.8, 3.9, and 3.10, 3.11.</p>
+<p>Tested support on Python 3.7, 3.8, 3.9, and 3.10, 3.11.</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code>$<span class="w"> </span>pdm<span class="w"> </span>add<span class="w"> </span>just-jobs
+<div class="pdoc-code codehilite">
+<pre><span></span><code>$<span class="w"> </span>pdm<span class="w"> </span>add<span class="w"> </span>just-jobs
 <span class="c1"># or</span>
 $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </span>--user<span class="w"> </span>just-jobs
 </code></pre>
-          </div>
+</div>
 
-          <h2 id="features">Features</h2>
+<h2 id="features">Features</h2>
 
-          <p>
-            just-jobs doesn't aim to replace the invocations that arq provides,
-            only wrap some of them to make job creation and execution easier and
-            better. It lets you:
-          </p>
+<p>just-jobs doesn't aim to replace the invocations that arq provides, only wrap some of them to make job creation and execution easier and better. It lets you:</p>
 
-          <ul>
-            <li>
-              Define and run non-async jobs. Passing a non-async
-              <code>@job</code> function to arq will run properly. Non-async
-              jobs can also be defined as either IO-bound or CPU-bound, which
-              changes how the job will be executed to prevent blocking the
-              asyncio event loop.
-            </li>
-            <li>
-              The arq <code><a href="#Context">Context</a></code> parameter now
-              works a lot like
-              <a
-                href="https://fastapi.tiangolo.com/advanced/using-request-directly/"
-                >FastAPI's <code>Request</code></a
-              >. It's no longer a required parameter, but if it exists, it will
-              get set. It doesn't have to be named <code>ctx</code> either, only
-              have the type <code><a href="#Context">Context</a></code
-              >.
-            </li>
-            <li>
-              Specify a single <code>RedisSettings</code> within your
-              <code>WorkerSettings</code> from which you can create a pool using
-              <code>Settings.create_pool()</code>.
-            </li>
-            <li>
-              Run jobs either immediately with the <code>.now()</code> function
-              or via normal arq enqueueing.
-            </li>
-            <li>
-              Use non-pickable job arguments and kwargs (supported by the
-              <a href="http://dill.rtfd.io/">dill</a> library).
-            </li>
-          </ul>
+<ul>
+<li>Define and run non-async jobs. Passing a non-async <code>@job</code> function to arq will run properly. Non-async jobs can also be defined as either IO-bound or CPU-bound, which changes how the job will be executed to prevent blocking the asyncio event loop.</li>
+<li>The arq <code><a href="#Context">Context</a></code> parameter now works a lot like <a href="https://fastapi.tiangolo.com/advanced/using-request-directly/">FastAPI's <code>Request</code></a>. It's no longer a required parameter, but if it exists, it will get set. It doesn't have to be named <code>ctx</code> either, only have the type <code><a href="#Context">Context</a></code>.</li>
+<li>Specify a single <code>RedisSettings</code> within your <code>WorkerSettings</code> from which you can create a pool using <code>Settings.create_pool()</code>.</li>
+<li>Run jobs either immediately or via normal arq enqueueing.</li>
+<li>Use non-pickable job arguments and kwargs (supported by the <a href="http://dill.rtfd.io/">dill</a> library).</li>
+</ul>
 
-          <h2 id="usage">Usage</h2>
+<h2 id="usage">Usage</h2>
 
-          <p>Using just-jobs is pretty straight forward:</p>
+<p>Using just-jobs is pretty straight forward:</p>
 
-          <h3 id="add-job-to-any-function-to-make-it-a-delayable-job">
-            Add <code>@job()</code> to any function to make it a delayable job.
-          </h3>
+<h3 id="add-job-to-any-function-to-make-it-a-delayable-job">Add <code>@job()</code> to any function to make it a delayable job.</h3>
 
-          <p>
-            If the job is synchronous, specify its job type so just-jobs knows
-            how to optimally run it. If you don't, you'll get an error. This
-            helps encourage thoughtful and intentional job design while ensuring
-            that the event loop is never blocked.
-          </p>
+<p>If the job is synchronous, specify its job type so just-jobs knows how to optimally run it. If you don't, you'll get an error. This helps encourage thoughtful and intentional job design while ensuring that the event loop is never blocked.</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code><span class="nd">@job</span><span class="p">(</span><span class="n">job_type</span><span class="o">=</span><span class="n"><a href="#JobType.CPU_BOUND">JobType.CPU_BOUND</a></span><span class="p">)</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="nd">@job</span><span class="p">(</span><span class="n">job_type</span><span class="o">=</span><span class="n"><a href="#JobType.CPU_BOUND">JobType.CPU_BOUND</a></span><span class="p">)</span>
 <span class="k">def</span> <span class="nf">complex_math</span><span class="p">(</span><span class="n">i</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">j</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">k</span><span class="p">:</span> <span class="nb">int</span><span class="p">)</span>
 </code></pre>
-          </div>
+</div>
 
-          <p>
-            If it's a coroutine function, you don't need to specify a job type
-            (and will get a warning if you do).
-          </p>
+<p>If it's a coroutine function, you don't need to specify a job type (and will get a warning if you do).</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code><span class="nd">@job</span><span class="p">()</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="nd">@job</span><span class="p">()</span>
 <span class="k">async</span> <span class="k">def</span> <span class="nf">poll_reddit</span><span class="p">(</span><span class="n">subr</span><span class="p">:</span> <span class="nb">str</span><span class="p">)</span>
 </code></pre>
-          </div>
+</div>
 
-          <h3 id="use-now-if-you-want-to-run-the-job-immediately">
-            Use <code>.now</code> if you want to run the job immediately.
-          </h3>
+<h3 id="invoke-a-job-normally-if-you-want-to-run-it-immediately">Invoke a job normally if you want to run it immediately.</h3>
 
-          <p>
-            Using <code>.now</code> allows you to run the job as if it were a
-            normal function. If you have logic that you only want to execute
-            when enqueued, include a parameter with type
-            <code><a href="#Context">Context</a></code> and check if it exists
-            at runtime (functions with a
-            <code><a href="#Context">Context</a></code> that are run immediately
-            will have that argument set to <code>None</code>).
-          </p>
+<p>Invoking a job as a regular function allows you to run a job as if it were one. If you have logic that you only want to execute when enqueued, include a parameter with type <code><a href="#Context">Context</a></code> and check if it exists at runtime (functions with a <code><a href="#Context">Context</a></code> that are run immediately will have that argument set to <code>None</code>).</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code><span class="nd">@job</span><span class="p">()</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="nd">@job</span><span class="p">()</span>
 <span class="k">async</span> <span class="k">def</span> <span class="nf">context_aware</span><span class="p">(</span><span class="n">ctx</span><span class="p">:</span> <span class="n">Context</span><span class="p">,</span> <span class="n">msg</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
     <span class="k">if</span> <span class="n">ctx</span><span class="p">:</span>
         <span class="c1"># enqueued then run by arq</span>
@@ -1413,48 +158,29 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
         <span class="c1"># invoked manually</span>
         <span class="k">return</span> <span class="sa">f</span><span class="s2">&quot;bye </span><span class="si">{</span><span class="n">msg</span><span class="si">}</span><span class="s2">&quot;</span>
 
-<span class="k">await</span> <span class="n">context_aware</span><span class="o">.</span><span class="n">now</span><span class="p">(</span><span class="s2">&quot;world&quot;</span><span class="p">)</span> <span class="o">==</span> <span class="s2">&quot;bye world&quot;</span>
+<span class="k">await</span> <span class="n">context_aware</span><span class="p">(</span><span class="s2">&quot;world&quot;</span><span class="p">)</span> <span class="o">==</span> <span class="s2">&quot;bye world&quot;</span>
 
 <span class="n">j</span> <span class="o">=</span> <span class="k">await</span> <span class="n">p</span><span class="o">.</span><span class="n">enqueue_job</span><span class="p">(</span><span class="s2">&quot;context_aware&quot;</span><span class="p">,</span> <span class="s2">&quot;world&quot;</span><span class="p">)</span>
 <span class="k">await</span> <span class="n">j</span><span class="o">.</span><span class="n">result</span><span class="p">()</span> <span class="o">==</span> <span class="s2">&quot;hello world&quot;</span>
 </code></pre>
-          </div>
+</div>
 
-          <h3 id="define-workersettings-using-the-basesettings-metaclass">
-            Define WorkerSettings using the
-            <code><a href="#BaseSettings">BaseSettings</a></code> metaclass.
-          </h3>
+<h3 id="define-workersettings-using-the-basesettings-metaclass">Define WorkerSettings using the <code><a href="#BaseSettings">BaseSettings</a></code> metaclass.</h3>
 
-          <p>
-            The execution logic that <code>@job</code> provides requires some
-            stuff. When you defining your WorkerSettings, you must declare
-            <code><a href="#BaseSettings">BaseSettings</a></code> as its
-            metaclass to ensure that stuff exists.
-          </p>
+<p>The execution logic that <code>@job</code> provides requires some stuff. When you defining your WorkerSettings, you must declare <code><a href="#BaseSettings">BaseSettings</a></code> as its metaclass to ensure that stuff exists.</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code><span class="k">class</span> <span class="nc">Settings</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">BaseSettings</span><span class="p">):</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="k">class</span> <span class="nc">Settings</span><span class="p">(</span><span class="n">metaclass</span><span class="o">=</span><span class="n">BaseSettings</span><span class="p">):</span>
     <span class="n">redis_settings</span> <span class="o">=</span> <span class="o">...</span>
 </code></pre>
-          </div>
+</div>
 
-          <h3 id="use-settingscreate_pool">
-            Use <code>Settings.create_pool()</code>.
-          </h3>
+<h3 id="use-settingscreate_pool">Use <code>Settings.create_pool()</code>.</h3>
 
-          <p>
-            While you may elect to use
-            <code>arq.connections.create_pool</code> as you would normally,
-            using the <code>create_pool</code> function provided by your
-            <code>Settings</code> class ensures the pool it creates always
-            matches your worker's Redis and serialization settings (it will be
-            less of a headache). It also lets you take advantage of additional
-            functionality, namely that it can be used as an auto-closing context
-            manager.
-          </p>
+<p>While you may elect to use <code>arq.connections.create_pool</code> as you would normally, using the <code>create_pool</code> function provided by your <code>Settings</code> class ensures the pool it creates always matches your worker's Redis and serialization settings (it will be less of a headache). It also lets you take advantage of additional functionality, namely that it can be used as an auto-closing context manager.</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code><span class="c1"># manually</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="c1"># manually</span>
 <span class="n">pool</span> <span class="o">=</span> <span class="k">await</span> <span class="n">Settings</span><span class="o">.</span><span class="n">create_pool</span><span class="p">()</span>
 <span class="k">await</span> <span class="n">pool</span><span class="o">.</span><span class="n">close</span><span class="p">(</span><span class="n">close_connection_pool</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 
@@ -1462,58 +188,34 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 <span class="k">async</span> <span class="k">with</span> <span class="n">Settings</span><span class="o">.</span><span class="n">create_pool</span><span class="p">()</span> <span class="k">as</span> <span class="n">pool</span><span class="p">:</span>
     <span class="o">...</span>
 </code></pre>
-          </div>
+</div>
 
-          <h3 id="enqueue-your-job">Enqueue your job.</h3>
+<h3 id="enqueue-your-job">Enqueue your job.</h3>
 
-          <p>
-            just-jobs doesn't change the way in which you enqueue your jobs.
-            Just use <code>await pool.enqueue_job(...)</code>.
-          </p>
+<p>just-jobs doesn't change the way in which you enqueue your jobs. Just use <code>await pool.enqueue_job(...)</code>.</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code><span class="k">await</span> <span class="n">pool</span><span class="o">.</span><span class="n">enqueue_job</span><span class="p">(</span><span class="s1">&#39;complex_math&#39;</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="k">await</span> <span class="n">pool</span><span class="o">.</span><span class="n">enqueue_job</span><span class="p">(</span><span class="s1">&#39;complex_math&#39;</span><span class="p">,</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">3</span><span class="p">)</span>
 </code></pre>
-          </div>
+</div>
 
-          <h2 id="caveats">Caveats</h2>
+<h2 id="caveats">Caveats</h2>
 
-          <ol>
-            <li>
-              <p>
-                <code>arq.func()</code> and <code>@job()</code> are mutually
-                exclusive. If you want to configure a job in the same way, pass
-                the settings you would have passed to <code>func()</code> to
-                <code>@job()</code> instead.
-              </p>
+<ol>
+<li><p><code>arq.func()</code> and <code>@job()</code> are mutually exclusive. If you want to configure a job in the same way, pass the settings you would have passed to <code>func()</code> to <code>@job()</code> instead.</p>
 
-              <div class="pdoc-code codehilite">
-                <pre><span></span><code><span class="nd">@job</span><span class="p">(</span><span class="n">job_type</span><span class="o">=</span><span class="n"><a href="#JobType.CPU_BOUND">JobType.CPU_BOUND</a></span><span class="p">,</span> <span class="n">keep_result_forever</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">max_tries</span><span class="o">=</span><span class="mi">10</span><span class="p">)</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="nd">@job</span><span class="p">(</span><span class="n">job_type</span><span class="o">=</span><span class="n"><a href="#JobType.CPU_BOUND">JobType.CPU_BOUND</a></span><span class="p">,</span> <span class="n">keep_result_forever</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span> <span class="n">max_tries</span><span class="o">=</span><span class="mi">10</span><span class="p">)</span>
 <span class="k">def</span> <span class="nf">task</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
   <span class="k">return</span> <span class="n">a</span> <span class="o">+</span> <span class="n">b</span>
 </code></pre>
-              </div>
-            </li>
-            <li>
-              <p>
-                There isn't support for asynchronous CPU-bound tasks. Currently,
-                job types only configure the execution behavior of synchronous
-                tasks (not coroutines). However, there are some valid cases for
-                CPU-bound tasks that also need to be run in an asyncio context.
-              </p>
+</div></li>
+<li><p>There isn't support for asynchronous CPU-bound tasks. Currently, job types only configure the execution behavior of synchronous tasks (not coroutines). However, there are some valid cases for CPU-bound tasks that also need to be run in an asyncio context.</p>
 
-              <p>
-                At the moment, the best way to achieve this will be to create a
-                synchronous CPU-bound task (so it runs in a separate process)
-                that then invokes a coroutine via <code>asyncio.run</code>. If
-                you intend on running the task in the current context from time
-                to time (with <code>.now</code>), just return the coroutine
-                instead and it will get automatically executed in the current
-                event loop.
-              </p>
+<p>At the moment, the best way to achieve this will be to create a synchronous CPU-bound task (so it runs in a separate process) that then invokes a coroutine via <code>asyncio.run</code>. If you intend on running the task in the current context from time to time, just return the coroutine instead and it will get automatically executed in the current event loop.</p>
 
-              <div class="pdoc-code codehilite">
-                <pre><span></span><code><span class="k">async</span> <span class="n">_async_task</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">c</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="k">async</span> <span class="n">_async_task</span><span class="p">(</span><span class="n">a</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">b</span><span class="p">:</span> <span class="nb">int</span><span class="p">,</span> <span class="n">c</span><span class="p">:</span> <span class="nb">int</span><span class="p">):</span>
    <span class="n">ab</span> <span class="o">=</span> <span class="k">await</span> <span class="n">add</span><span class="p">(</span><span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">)</span>
    <span class="k">return</span> <span class="k">await</span> <span class="n">add</span><span class="p">(</span><span class="n">ab</span><span class="p">,</span> <span class="n">c</span><span class="p">)</span>
 
@@ -1522,24 +224,15 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
    <span class="n">task</span> <span class="o">=</span> <span class="n">_async_task</span><span class="p">(</span><span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">c</span><span class="p">)</span>
    <span class="k">return</span> <span class="n">asyncio</span><span class="o">.</span><span class="n">run</span><span class="p">(</span><span class="n">task</span><span class="p">)</span> <span class="k">if</span> <span class="n">ctx</span> <span class="k">else</span> <span class="n">task</span>
 </code></pre>
-              </div>
-            </li>
-          </ol>
+</div></li>
+</ol>
 
-          <h2 id="example">Example</h2>
+<h2 id="example">Example</h2>
 
-          <p>
-            The complete example is available at
-            <a
-              href="https://github.com/thearchitector/just-jobs/blob/main/docs/example.py"
-              >docs/example.py</a
-            >
-            and should work out of the box. The snippet below is just an excerpt
-            to show the features described above:
-          </p>
+<p>The complete example is available at <a href="https://github.com/thearchitector/just-jobs/blob/main/docs/example.py">docs/example.py</a> and should work out of the box. The snippet below is just an excerpt to show the features described above:</p>
 
-          <div class="pdoc-code codehilite">
-            <pre><span></span><code><span class="kn">from</span> <span class="nn">just_jobs</span> <span class="kn">import</span> <span class="n">BaseSettings</span><span class="p">,</span> <span class="n">Context</span><span class="p">,</span> <span class="n">JobType</span><span class="p">,</span> <span class="n">job</span>
+<div class="pdoc-code codehilite">
+<pre><span></span><code><span class="kn">from</span> <span class="nn">just_jobs</span> <span class="kn">import</span> <span class="n">BaseSettings</span><span class="p">,</span> <span class="n">Context</span><span class="p">,</span> <span class="n">JobType</span><span class="p">,</span> <span class="n">job</span>
 
 <span class="nd">@job</span><span class="p">()</span>
 <span class="k">async</span> <span class="k">def</span> <span class="nf">async_task</span><span class="p">(</span><span class="n">url</span><span class="p">:</span> <span class="nb">str</span><span class="p">):</span>
@@ -1560,50 +253,27 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
     <span class="c1"># create a Redis pool using the Settings already defined</span>
     <span class="n">pool</span> <span class="o">=</span> <span class="k">await</span> <span class="n">Settings</span><span class="o">.</span><span class="n">create_pool</span><span class="p">()</span>
     <span class="c1"># run the_task right now and return the url</span>
-    <span class="c1"># even though this is a sync function, `.now` returns an awaitable</span>
-    <span class="n">url</span> <span class="o">=</span> <span class="k">await</span> <span class="n">sync_task</span><span class="o">.</span><span class="n">now</span><span class="p">(</span><span class="s2">&quot;https://www.theglassfiles.com&quot;</span><span class="p">)</span>
+    <span class="n">url</span> <span class="o">=</span> <span class="n">sync_task</span><span class="p">(</span><span class="s2">&quot;https://www.theglassfiles.com&quot;</span><span class="p">)</span>
 
     <span class="k">await</span> <span class="n">pool</span><span class="o">.</span><span class="n">enqueue_job</span><span class="p">(</span><span class="s2">&quot;async_task&quot;</span><span class="p">,</span> <span class="s2">&quot;https://www.eliasfgabriel.com&quot;</span><span class="p">)</span>
     <span class="k">await</span> <span class="n">pool</span><span class="o">.</span><span class="n">enqueue_job</span><span class="p">(</span><span class="s2">&quot;sync_task&quot;</span><span class="p">,</span> <span class="s2">&quot;https://gianturl.net&quot;</span><span class="p">)</span>
 
     <span class="k">await</span> <span class="n">pool</span><span class="o">.</span><span class="n">close</span><span class="p">(</span><span class="n">close_connection_pool</span><span class="o">=</span><span class="kc">True</span><span class="p">)</span>
 </code></pre>
-          </div>
+</div>
 
-          <h2 id="license">License</h2>
+<h2 id="license">License</h2>
 
-          <p>
-            This software is licensed under the
-            <a href="LICENSE">3-Clause BSD License</a>.
-          </p>
+<p>This software is licensed under the <a href="LICENSE">3-Clause BSD License</a>.</p>
 
-          <p>
-            This package is <a href="https://treeware.earth">Treeware</a>. If
-            you use it in production, consider
-            <a
-              href="https://ecologi.com/eliasgabriel?r=6128126916bfab8bd051026c"
-              ><strong>buying the world a tree</strong></a
-            >
-            to thank me for my work. By contributing to my forest, you’ll be
-            creating employment for local families and restoring wildlife
-            habitats.
-          </p>
-        </div>
+<p>This package is <a href="https://treeware.earth">Treeware</a>. If you use it in production, consider <a href="https://ecologi.com/eliasgabriel?r=6128126916bfab8bd051026c"><strong>buying the world a tree</strong></a> to thank me for my work. By contributing to my forest, you’ll be creating employment for local families and restoring wildlife habitats.</p>
+</div>
 
-        <input
-          id="mod-just_jobs-view-source"
-          class="view-source-toggle-state"
-          type="checkbox"
-          aria-hidden="true"
-          tabindex="-1"
-        />
+                        <input id="mod-just_jobs-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
 
-        <label class="view-source-button" for="mod-just_jobs-view-source"
-          ><span>View Source</span></label
-        >
+                        <label class="view-source-button" for="mod-just_jobs-view-source"><span>View Source</span></label>
 
-        <div class="pdoc-code codehilite">
-          <pre><span></span><span id="L-1"><a href="#L-1"><span class="linenos">1</span></a><span class="sd">&quot;&quot;&quot;.. include:: ../README.md&quot;&quot;&quot;</span>
+                        <div class="pdoc-code codehilite"><pre><span></span><span id="L-1"><a href="#L-1"><span class="linenos">1</span></a><span class="sd">&quot;&quot;&quot;.. include:: ../README.md&quot;&quot;&quot;</span>
 </span><span id="L-2"><a href="#L-2"><span class="linenos">2</span></a>
 </span><span id="L-3"><a href="#L-3"><span class="linenos">3</span></a><span class="kn">from</span> <span class="nn">.job_type</span> <span class="kn">import</span> <span class="n">JobType</span>
 </span><span id="L-4"><a href="#L-4"><span class="linenos">4</span></a><span class="kn">from</span> <span class="nn">.jobs</span> <span class="kn">import</span> <span class="n">job</span>
@@ -1611,148 +281,72 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="L-6"><a href="#L-6"><span class="linenos">6</span></a><span class="kn">from</span> <span class="nn">.typing</span> <span class="kn">import</span> <span class="n">Context</span>
 </span><span id="L-7"><a href="#L-7"><span class="linenos">7</span></a>
 </span><span id="L-8"><a href="#L-8"><span class="linenos">8</span></a><span class="n">__all__</span> <span class="o">=</span> <span class="p">[</span><span class="s2">&quot;job&quot;</span><span class="p">,</span> <span class="s2">&quot;JobType&quot;</span><span class="p">,</span> <span class="s2">&quot;BaseSettings&quot;</span><span class="p">,</span> <span class="s2">&quot;Context&quot;</span><span class="p">]</span>
-</span></pre>
-        </div>
-      </section>
-      <section id="job">
-        <input
-          id="job-view-source"
-          class="view-source-toggle-state"
-          type="checkbox"
-          aria-hidden="true"
-          tabindex="-1"
-        />
-        <div class="attr function">
-          <span class="def">def</span>
-          <span class="name">job</span
-          ><span class="signature pdoc-code multiline"
-            >(<span class="param">
-              <span class="n">job_type</span><span class="p">:</span>
-              <span class="n">Optional</span><span class="p">[</span
-              ><span class="n"><a href="#JobType">just_jobs.JobType</a></span
-              ><span class="p">]</span> <span class="o">=</span>
-              <span class="kc">None</span>,</span
-            ><span class="param">
-              <span class="n">name</span><span class="p">:</span>
-              <span class="n">Optional</span><span class="p">[</span
-              ><span class="nb">str</span><span class="p">]</span>
-              <span class="o">=</span> <span class="kc">None</span>,</span
-            ><span class="param">
-              <span class="n">keep_result</span><span class="p">:</span>
-              <span class="n">Union</span><span class="p">[</span
-              ><span class="nb">int</span><span class="p">,</span>
-              <span class="nb">float</span><span class="p">,</span>
-              <span class="n">datetime</span><span class="o">.</span
-              ><span class="n">timedelta</span><span class="p">,</span>
-              <span class="n">NoneType</span><span class="p">]</span>
-              <span class="o">=</span> <span class="kc">None</span>,</span
-            ><span class="param">
-              <span class="n">timeout</span><span class="p">:</span>
-              <span class="n">Union</span><span class="p">[</span
-              ><span class="nb">int</span><span class="p">,</span>
-              <span class="nb">float</span><span class="p">,</span>
-              <span class="n">datetime</span><span class="o">.</span
-              ><span class="n">timedelta</span><span class="p">,</span>
-              <span class="n">NoneType</span><span class="p">]</span>
-              <span class="o">=</span> <span class="kc">None</span>,</span
-            ><span class="param">
-              <span class="n">keep_result_forever</span
-              ><span class="p">:</span> <span class="n">Optional</span
-              ><span class="p">[</span><span class="nb">bool</span
-              ><span class="p">]</span> <span class="o">=</span>
-              <span class="kc">None</span>,</span
-            ><span class="param">
-              <span class="n">max_tries</span><span class="p">:</span>
-              <span class="n">Optional</span><span class="p">[</span
-              ><span class="nb">int</span><span class="p">]</span>
-              <span class="o">=</span> <span class="kc">None</span></span
-            ><span class="return-annotation"
-              >) -> <span class="n">Callable</span><span class="p">[[</span
-              ><span class="n">Callable</span><span class="p">[</span
-              ><span class="o">...</span><span class="p">,</span>
-              <span class="n">Union</span><span class="p">[</span
-              ><span class="n">Any</span><span class="p">,</span>
-              <span class="n">Awaitable</span><span class="p">[</span
-              ><span class="n">Any</span><span class="p">]]]],</span>
-              <span class="n">just_jobs</span><span class="o">.</span
-              ><span class="n">jobs</span><span class="o">.</span
-              ><span class="n">_job</span><span class="p">[</span
-              ><span class="n">Any</span><span class="p">]]</span>:</span
-            ></span
-          >
+</span></pre></div>
 
-          <label class="view-source-button" for="job-view-source"
-            ><span>View Source</span></label
-          >
-        </div>
-        <a class="headerlink" href="#job"></a>
-        <div class="pdoc-code codehilite">
-          <pre><span></span><span id="job-90"><a href="#job-90"><span class="linenos"> 90</span></a><span class="k">def</span> <span class="nf">job</span><span class="p">(</span>
-</span><span id="job-91"><a href="#job-91"><span class="linenos"> 91</span></a>    <span class="n">job_type</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">JobType</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-</span><span id="job-92"><a href="#job-92"><span class="linenos"> 92</span></a>    <span class="n">name</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-</span><span id="job-93"><a href="#job-93"><span class="linenos"> 93</span></a>    <span class="n">keep_result</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">SecondsTimedelta</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-</span><span id="job-94"><a href="#job-94"><span class="linenos"> 94</span></a>    <span class="n">timeout</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">SecondsTimedelta</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-</span><span id="job-95"><a href="#job-95"><span class="linenos"> 95</span></a>    <span class="n">keep_result_forever</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">bool</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-</span><span id="job-96"><a href="#job-96"><span class="linenos"> 96</span></a>    <span class="n">max_tries</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
-</span><span id="job-97"><a href="#job-97"><span class="linenos"> 97</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Callable</span><span class="p">[[</span><span class="n">ArqCallable</span><span class="p">[</span><span class="n">Any</span><span class="p">]],</span> <span class="n">_job</span><span class="p">[</span><span class="n">Any</span><span class="p">]]:</span>
-</span><span id="job-98"><a href="#job-98"><span class="linenos"> 98</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
-</span><span id="job-99"><a href="#job-99"><span class="linenos"> 99</span></a><span class="sd">    Creates an async enqueueable job from the provided function. The function may be</span>
-</span><span id="job-100"><a href="#job-100"><span class="linenos">100</span></a><span class="sd">    synchronous or a coroutine. If synchronous, the job will be run in either a</span>
-</span><span id="job-101"><a href="#job-101"><span class="linenos">101</span></a><span class="sd">    thread or process depending on its `JobType`.</span>
-</span><span id="job-102"><a href="#job-102"><span class="linenos">102</span></a>
-</span><span id="job-103"><a href="#job-103"><span class="linenos">103</span></a><span class="sd">    Synchronous jobs are required to specify their `job_type`. If a job type is</span>
-</span><span id="job-104"><a href="#job-104"><span class="linenos">104</span></a><span class="sd">    specified for a coroutine, a warning will be thrown (but will still execute).</span>
-</span><span id="job-105"><a href="#job-105"><span class="linenos">105</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span><span id="job-106"><a href="#job-106"><span class="linenos">106</span></a>    <span class="k">return</span> <span class="k">lambda</span> <span class="n">func</span><span class="p">:</span> <span class="n">_job</span><span class="p">(</span>
-</span><span id="job-107"><a href="#job-107"><span class="linenos">107</span></a>        <span class="n">func</span><span class="o">=</span><span class="n">func</span><span class="p">,</span>
-</span><span id="job-108"><a href="#job-108"><span class="linenos">108</span></a>        <span class="n">job_type</span><span class="o">=</span><span class="n">job_type</span><span class="p">,</span>
-</span><span id="job-109"><a href="#job-109"><span class="linenos">109</span></a>        <span class="c1"># inherited</span>
-</span><span id="job-110"><a href="#job-110"><span class="linenos">110</span></a>        <span class="n">name</span><span class="o">=</span><span class="n">name</span> <span class="ow">or</span> <span class="n">func</span><span class="o">.</span><span class="vm">__qualname__</span><span class="p">,</span>
-</span><span id="job-111"><a href="#job-111"><span class="linenos">111</span></a>        <span class="n">timeout_s</span><span class="o">=</span><span class="n">to_seconds</span><span class="p">(</span><span class="n">timeout</span><span class="p">),</span>
-</span><span id="job-112"><a href="#job-112"><span class="linenos">112</span></a>        <span class="n">keep_result_s</span><span class="o">=</span><span class="n">to_seconds</span><span class="p">(</span><span class="n">keep_result</span><span class="p">),</span>
-</span><span id="job-113"><a href="#job-113"><span class="linenos">113</span></a>        <span class="n">keep_result_forever</span><span class="o">=</span><span class="n">keep_result_forever</span><span class="p">,</span>
-</span><span id="job-114"><a href="#job-114"><span class="linenos">114</span></a>        <span class="n">max_tries</span><span class="o">=</span><span class="n">max_tries</span><span class="p">,</span>
-</span><span id="job-115"><a href="#job-115"><span class="linenos">115</span></a>    <span class="p">)</span>
-</span></pre>
-        </div>
 
-        <div class="docstring">
-          <p>
-            Creates an async enqueueable job from the provided function. The
-            function may be synchronous or a coroutine. If synchronous, the job
-            will be run in either a thread or process depending on its
-            <code><a href="#JobType">JobType</a></code
-            >.
-          </p>
+            </section>
+                <section id="job">
+                            <input id="job-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">job</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="n">job_type</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n"><a href="#JobType">just_jobs.JobType</a></span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">name</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">keep_result</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">int</span><span class="p">,</span> <span class="nb">float</span><span class="p">,</span> <span class="n">datetime</span><span class="o">.</span><span class="n">timedelta</span><span class="p">,</span> <span class="n">NoneType</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">timeout</span><span class="p">:</span> <span class="n">Union</span><span class="p">[</span><span class="nb">int</span><span class="p">,</span> <span class="nb">float</span><span class="p">,</span> <span class="n">datetime</span><span class="o">.</span><span class="n">timedelta</span><span class="p">,</span> <span class="n">NoneType</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">keep_result_forever</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">bool</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">max_tries</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span></span><span class="return-annotation">) -> <span class="n">Callable</span><span class="p">[[</span><span class="n">Callable</span><span class="p">[</span><span class="o">...</span><span class="p">,</span> <span class="n">Union</span><span class="p">[</span><span class="n">Any</span><span class="p">,</span> <span class="n">Awaitable</span><span class="p">[</span><span class="n">Any</span><span class="p">]]]],</span> <span class="n">just_jobs</span><span class="o">.</span><span class="n">jobs</span><span class="o">.</span><span class="n">_job</span><span class="p">[</span><span class="n">Any</span><span class="p">]]</span>:</span></span>
 
-          <p>
-            Synchronous jobs are required to specify their
-            <code>job_type</code>. If a job type is specified for a coroutine, a
-            warning will be thrown (but will still execute).
-          </p>
-        </div>
-      </section>
-      <section id="JobType">
-        <input
-          id="JobType-view-source"
-          class="view-source-toggle-state"
-          type="checkbox"
-          aria-hidden="true"
-          tabindex="-1"
-        />
-        <div class="attr class">
-          <span class="def">class</span>
-          <span class="name">JobType</span><wbr />(<span class="base"
-            >enum.Enum</span
-          >):
+                <label class="view-source-button" for="job-view-source"><span>View Source</span></label>
 
-          <label class="view-source-button" for="JobType-view-source"
-            ><span>View Source</span></label
-          >
-        </div>
-        <a class="headerlink" href="#JobType"></a>
-        <div class="pdoc-code codehilite">
-          <pre><span></span><span id="JobType-5"><a href="#JobType-5"><span class="linenos"> 5</span></a><span class="k">class</span> <span class="nc">JobType</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
+    </div>
+    <a class="headerlink" href="#job"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="job-101"><a href="#job-101"><span class="linenos">101</span></a><span class="k">def</span> <span class="nf">job</span><span class="p">(</span>
+</span><span id="job-102"><a href="#job-102"><span class="linenos">102</span></a>    <span class="n">job_type</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">JobType</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="job-103"><a href="#job-103"><span class="linenos">103</span></a>    <span class="n">name</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="job-104"><a href="#job-104"><span class="linenos">104</span></a>    <span class="n">keep_result</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">SecondsTimedelta</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="job-105"><a href="#job-105"><span class="linenos">105</span></a>    <span class="n">timeout</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">SecondsTimedelta</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="job-106"><a href="#job-106"><span class="linenos">106</span></a>    <span class="n">keep_result_forever</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">bool</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="job-107"><a href="#job-107"><span class="linenos">107</span></a>    <span class="n">max_tries</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">int</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span><span class="p">,</span>
+</span><span id="job-108"><a href="#job-108"><span class="linenos">108</span></a><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Callable</span><span class="p">[[</span><span class="n">ArqCallable</span><span class="p">[</span><span class="n">Any</span><span class="p">]],</span> <span class="n">_job</span><span class="p">[</span><span class="n">Any</span><span class="p">]]:</span>
+</span><span id="job-109"><a href="#job-109"><span class="linenos">109</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
+</span><span id="job-110"><a href="#job-110"><span class="linenos">110</span></a><span class="sd">    Creates an async enqueueable job from the provided function. The function may be</span>
+</span><span id="job-111"><a href="#job-111"><span class="linenos">111</span></a><span class="sd">    synchronous or a coroutine. If synchronous, the job will be run in either a</span>
+</span><span id="job-112"><a href="#job-112"><span class="linenos">112</span></a><span class="sd">    thread or process depending on its `JobType`.</span>
+</span><span id="job-113"><a href="#job-113"><span class="linenos">113</span></a>
+</span><span id="job-114"><a href="#job-114"><span class="linenos">114</span></a><span class="sd">    Synchronous jobs are required to specify their `job_type`. If a job type is</span>
+</span><span id="job-115"><a href="#job-115"><span class="linenos">115</span></a><span class="sd">    specified for a coroutine, a warning will be thrown (but will still execute).</span>
+</span><span id="job-116"><a href="#job-116"><span class="linenos">116</span></a><span class="sd">    &quot;&quot;&quot;</span>
+</span><span id="job-117"><a href="#job-117"><span class="linenos">117</span></a>    <span class="k">return</span> <span class="k">lambda</span> <span class="n">func</span><span class="p">:</span> <span class="n">_job</span><span class="p">(</span>
+</span><span id="job-118"><a href="#job-118"><span class="linenos">118</span></a>        <span class="n">func</span><span class="o">=</span><span class="n">func</span><span class="p">,</span>
+</span><span id="job-119"><a href="#job-119"><span class="linenos">119</span></a>        <span class="n">job_type</span><span class="o">=</span><span class="n">job_type</span><span class="p">,</span>
+</span><span id="job-120"><a href="#job-120"><span class="linenos">120</span></a>        <span class="c1"># inherited</span>
+</span><span id="job-121"><a href="#job-121"><span class="linenos">121</span></a>        <span class="n">name</span><span class="o">=</span><span class="n">name</span> <span class="ow">or</span> <span class="n">func</span><span class="o">.</span><span class="vm">__qualname__</span><span class="p">,</span>
+</span><span id="job-122"><a href="#job-122"><span class="linenos">122</span></a>        <span class="n">timeout_s</span><span class="o">=</span><span class="n">to_seconds</span><span class="p">(</span><span class="n">timeout</span><span class="p">),</span>
+</span><span id="job-123"><a href="#job-123"><span class="linenos">123</span></a>        <span class="n">keep_result_s</span><span class="o">=</span><span class="n">to_seconds</span><span class="p">(</span><span class="n">keep_result</span><span class="p">),</span>
+</span><span id="job-124"><a href="#job-124"><span class="linenos">124</span></a>        <span class="n">keep_result_forever</span><span class="o">=</span><span class="n">keep_result_forever</span><span class="p">,</span>
+</span><span id="job-125"><a href="#job-125"><span class="linenos">125</span></a>        <span class="n">max_tries</span><span class="o">=</span><span class="n">max_tries</span><span class="p">,</span>
+</span><span id="job-126"><a href="#job-126"><span class="linenos">126</span></a>    <span class="p">)</span>
+</span></pre></div>
+
+
+            <div class="docstring"><p>Creates an async enqueueable job from the provided function. The function may be
+synchronous or a coroutine. If synchronous, the job will be run in either a
+thread or process depending on its <code><a href="#JobType">JobType</a></code>.</p>
+
+<p>Synchronous jobs are required to specify their <code>job_type</code>. If a job type is
+specified for a coroutine, a warning will be thrown (but will still execute).</p>
+</div>
+
+
+                </section>
+                <section id="JobType">
+                            <input id="JobType-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">JobType</span><wbr>(<span class="base">enum.Enum</span>):
+
+                <label class="view-source-button" for="JobType-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#JobType"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="JobType-5"><a href="#JobType-5"><span class="linenos"> 5</span></a><span class="k">class</span> <span class="nc">JobType</span><span class="p">(</span><span class="n">Enum</span><span class="p">):</span>
 </span><span id="JobType-6"><a href="#JobType-6"><span class="linenos"> 6</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;Indicates the performance characteristic of the job to run.&quot;&quot;&quot;</span>
 </span><span id="JobType-7"><a href="#JobType-7"><span class="linenos"> 7</span></a>
 </span><span id="JobType-8"><a href="#JobType-8"><span class="linenos"> 8</span></a>    <span class="n">IO_BOUND</span> <span class="o">=</span> <span class="s2">&quot;io-bound&quot;</span>
@@ -1769,84 +363,69 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="JobType-19"><a href="#JobType-19"><span class="linenos">19</span></a><span class="sd">    calculations) rather than wait for external services. Because they operate </span>
 </span><span id="JobType-20"><a href="#JobType-20"><span class="linenos">20</span></a><span class="sd">    continuously and hold the GIL, CPU-bound jobs run in a ProcessPoolExecutor.</span>
 </span><span id="JobType-21"><a href="#JobType-21"><span class="linenos">21</span></a><span class="sd">    &quot;&quot;&quot;</span>
-</span></pre>
-        </div>
+</span></pre></div>
 
-        <div class="docstring">
-          <p>Indicates the performance characteristic of the job to run.</p>
-        </div>
 
-        <div id="JobType.IO_BOUND" class="classattr">
-          <div class="attr variable">
-            <span class="name">IO_BOUND</span> =
-            <span class="default_value"
-              >&lt;<a href="#JobType.IO_BOUND">JobType.IO_BOUND</a>:
-              &#39;io-bound&#39;&gt;</span
-            >
-          </div>
-          <a class="headerlink" href="#JobType.IO_BOUND"></a>
+            <div class="docstring"><p>Indicates the performance characteristic of the job to run.</p>
+</div>
 
-          <div class="docstring">
-            <p>
-              IO-bound tasks typically spend a majority of their time waiting
-              for external services to complete, such as when read / writing to
-              disk or sending / receiving network packets. Since they do not
-              hold the GIL during that downtime, IO-bound jobs run in a
-              ThreadPoolExecutor.
-            </p>
-          </div>
-        </div>
-        <div id="JobType.CPU_BOUND" class="classattr">
-          <div class="attr variable">
-            <span class="name">CPU_BOUND</span> =
-            <span class="default_value"
-              >&lt;<a href="#JobType.CPU_BOUND">JobType.CPU_BOUND</a>:
-              &#39;cpu-bound&#39;&gt;</span
-            >
-          </div>
-          <a class="headerlink" href="#JobType.CPU_BOUND"></a>
 
-          <div class="docstring">
-            <p>
-              CPU-bound tasks typically perform many contiguous operations (like
-              complex calculations) rather than wait for external services.
-              Because they operate continuously and hold the GIL, CPU-bound jobs
-              run in a ProcessPoolExecutor.
-            </p>
-          </div>
-        </div>
-        <div class="inherited">
-          <h5>Inherited Members</h5>
-          <dl>
-            <div>
-              <dt>enum.Enum</dt>
-              <dd id="JobType.name" class="variable">name</dd>
-              <dd id="JobType.value" class="variable">value</dd>
+                            <div id="JobType.IO_BOUND" class="classattr">
+                                <div class="attr variable">
+            <span class="name">IO_BOUND</span>        =
+<span class="default_value">&lt;<a href="#JobType.IO_BOUND">JobType.IO_BOUND</a>: &#39;io-bound&#39;&gt;</span>
+
+        
+    </div>
+    <a class="headerlink" href="#JobType.IO_BOUND"></a>
+    
+            <div class="docstring"><p>IO-bound tasks typically spend a majority of their time waiting for external
+services to complete, such as when read / writing to disk or sending / receiving
+network packets. Since they do not hold the GIL during that downtime, IO-bound
+jobs run in a ThreadPoolExecutor.</p>
+</div>
+
+
+                            </div>
+                            <div id="JobType.CPU_BOUND" class="classattr">
+                                <div class="attr variable">
+            <span class="name">CPU_BOUND</span>        =
+<span class="default_value">&lt;<a href="#JobType.CPU_BOUND">JobType.CPU_BOUND</a>: &#39;cpu-bound&#39;&gt;</span>
+
+        
+    </div>
+    <a class="headerlink" href="#JobType.CPU_BOUND"></a>
+    
+            <div class="docstring"><p>CPU-bound tasks typically perform many contiguous operations (like complex
+calculations) rather than wait for external services. Because they operate 
+continuously and hold the GIL, CPU-bound jobs run in a ProcessPoolExecutor.</p>
+</div>
+
+
+                            </div>
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>enum.Enum</dt>
+                                <dd id="JobType.name" class="variable">name</dd>
+                <dd id="JobType.value" class="variable">value</dd>
+
             </div>
-          </dl>
-        </div>
-      </section>
-      <section id="BaseSettings">
-        <input
-          id="BaseSettings-view-source"
-          class="view-source-toggle-state"
-          type="checkbox"
-          aria-hidden="true"
-          tabindex="-1"
-        />
-        <div class="attr class">
-          <span class="def">class</span>
-          <span class="name">BaseSettings</span><wbr />(<span class="base"
-            >builtins.type</span
-          >):
+                                </dl>
+                            </div>
+                </section>
+                <section id="BaseSettings">
+                            <input id="BaseSettings-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr class">
+            
+    <span class="def">class</span>
+    <span class="name">BaseSettings</span><wbr>(<span class="base">builtins.type</span>):
 
-          <label class="view-source-button" for="BaseSettings-view-source"
-            ><span>View Source</span></label
-          >
-        </div>
-        <a class="headerlink" href="#BaseSettings"></a>
-        <div class="pdoc-code codehilite">
-          <pre><span></span><span id="BaseSettings-24"><a href="#BaseSettings-24"><span class="linenos"> 24</span></a><span class="k">class</span> <span class="nc">BaseSettings</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
+                <label class="view-source-button" for="BaseSettings-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#BaseSettings"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="BaseSettings-24"><a href="#BaseSettings-24"><span class="linenos"> 24</span></a><span class="k">class</span> <span class="nc">BaseSettings</span><span class="p">(</span><span class="nb">type</span><span class="p">):</span>
 </span><span id="BaseSettings-25"><a href="#BaseSettings-25"><span class="linenos"> 25</span></a><span class="w">    </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="BaseSettings-26"><a href="#BaseSettings-26"><span class="linenos"> 26</span></a><span class="sd">    A metaclass for defining WorkerSettings to pass to an arq process. This enables</span>
 </span><span id="BaseSettings-27"><a href="#BaseSettings-27"><span class="linenos"> 27</span></a><span class="sd">    using the built-in JobType and executor pool logic, as well as secure remote job</span>
@@ -1945,50 +524,28 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="BaseSettings-120"><a href="#BaseSettings-120"><span class="linenos">120</span></a>            <span class="n">unpackj</span><span class="o">=</span><span class="bp">cls</span><span class="o">.</span><span class="n">job_deserializer</span><span class="p">,</span>
 </span><span id="BaseSettings-121"><a href="#BaseSettings-121"><span class="linenos">121</span></a>            <span class="n">kwargs</span><span class="o">=</span><span class="n">kwargs</span><span class="p">,</span>
 </span><span id="BaseSettings-122"><a href="#BaseSettings-122"><span class="linenos">122</span></a>        <span class="p">)</span>
-</span></pre>
-        </div>
+</span></pre></div>
 
-        <div class="docstring">
-          <p>
-            A metaclass for defining WorkerSettings to pass to an arq process.
-            This enables using the built-in JobType and executor pool logic, as
-            well as secure remote job serialization and parsing.
-          </p>
-        </div>
 
-        <div id="BaseSettings.on_startup" class="classattr">
-          <input
-            id="BaseSettings.on_startup-view-source"
-            class="view-source-toggle-state"
-            type="checkbox"
-            aria-hidden="true"
-            tabindex="-1"
-          />
-          <div class="attr function">
-            <div class="decorator">@staticmethod</div>
+            <div class="docstring"><p>A metaclass for defining WorkerSettings to pass to an arq process. This enables
+using the built-in JobType and executor pool logic, as well as secure remote job
+serialization and parsing.</p>
+</div>
 
-            <span class="def">async def</span>
-            <span class="name">on_startup</span
-            ><span class="signature pdoc-code condensed"
-              >(<span class="param"
-                ><span class="n">ctx</span><span class="p">:</span>
-                <span class="n">Dict</span><span class="p">[</span
-                ><span class="n">Any</span><span class="p">,</span>
-                <span class="n">Any</span><span class="p">]</span></span
-              ><span class="return-annotation"
-                >) -> <span class="kc">None</span>:</span
-              ></span
-            >
 
-            <label
-              class="view-source-button"
-              for="BaseSettings.on_startup-view-source"
-              ><span>View Source</span></label
-            >
-          </div>
-          <a class="headerlink" href="#BaseSettings.on_startup"></a>
-          <div class="pdoc-code codehilite">
-            <pre><span></span><span id="BaseSettings.on_startup-44"><a href="#BaseSettings.on_startup-44"><span class="linenos">44</span></a>    <span class="nd">@staticmethod</span>
+                            <div id="BaseSettings.on_startup" class="classattr">
+                                        <input id="BaseSettings.on_startup-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+                    <div class="decorator">@staticmethod</div>
+
+        <span class="def">async def</span>
+        <span class="name">on_startup</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">ctx</span><span class="p">:</span> <span class="n">Dict</span><span class="p">[</span><span class="n">Any</span><span class="p">,</span> <span class="n">Any</span><span class="p">]</span></span><span class="return-annotation">) -> <span class="kc">None</span>:</span></span>
+
+                <label class="view-source-button" for="BaseSettings.on_startup-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#BaseSettings.on_startup"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="BaseSettings.on_startup-44"><a href="#BaseSettings.on_startup-44"><span class="linenos">44</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="BaseSettings.on_startup-45"><a href="#BaseSettings.on_startup-45"><span class="linenos">45</span></a>    <span class="k">async</span> <span class="k">def</span> <span class="nf">on_startup</span><span class="p">(</span><span class="n">ctx</span><span class="p">:</span> <span class="n">Context</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
 </span><span id="BaseSettings.on_startup-46"><a href="#BaseSettings.on_startup-46"><span class="linenos">46</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="BaseSettings.on_startup-47"><a href="#BaseSettings.on_startup-47"><span class="linenos">47</span></a><span class="sd">        Starts the thread and process pool executors for downstream synchronous job</span>
@@ -2003,49 +560,28 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="BaseSettings.on_startup-56"><a href="#BaseSettings.on_startup-56"><span class="linenos">56</span></a>            <span class="n">JobType</span><span class="o">.</span><span class="n">IO_BOUND</span><span class="p">:</span> <span class="n">ThreadPoolExecutor</span><span class="p">(</span><span class="n">max_workers</span><span class="o">=</span><span class="n">MAX_THREAD_WORKERS</span><span class="p">),</span>
 </span><span id="BaseSettings.on_startup-57"><a href="#BaseSettings.on_startup-57"><span class="linenos">57</span></a>            <span class="n">JobType</span><span class="o">.</span><span class="n">CPU_BOUND</span><span class="p">:</span> <span class="n">ProcessPoolExecutor</span><span class="p">(</span><span class="n">max_workers</span><span class="o">=</span><span class="n">MAX_PROCESS_WORKERS</span><span class="p">),</span>
 </span><span id="BaseSettings.on_startup-58"><a href="#BaseSettings.on_startup-58"><span class="linenos">58</span></a>        <span class="p">}</span>
-</span></pre>
-          </div>
+</span></pre></div>
 
-          <div class="docstring">
-            <p>
-              Starts the thread and process pool executors for downstream
-              synchronous job execution.
-            </p>
-          </div>
-        </div>
-        <div id="BaseSettings.on_shutdown" class="classattr">
-          <input
-            id="BaseSettings.on_shutdown-view-source"
-            class="view-source-toggle-state"
-            type="checkbox"
-            aria-hidden="true"
-            tabindex="-1"
-          />
-          <div class="attr function">
-            <div class="decorator">@staticmethod</div>
 
-            <span class="def">async def</span>
-            <span class="name">on_shutdown</span
-            ><span class="signature pdoc-code condensed"
-              >(<span class="param"
-                ><span class="n">ctx</span><span class="p">:</span>
-                <span class="n">Dict</span><span class="p">[</span
-                ><span class="n">Any</span><span class="p">,</span>
-                <span class="n">Any</span><span class="p">]</span></span
-              ><span class="return-annotation"
-                >) -> <span class="kc">None</span>:</span
-              ></span
-            >
+            <div class="docstring"><p>Starts the thread and process pool executors for downstream synchronous job
+execution.</p>
+</div>
 
-            <label
-              class="view-source-button"
-              for="BaseSettings.on_shutdown-view-source"
-              ><span>View Source</span></label
-            >
-          </div>
-          <a class="headerlink" href="#BaseSettings.on_shutdown"></a>
-          <div class="pdoc-code codehilite">
-            <pre><span></span><span id="BaseSettings.on_shutdown-60"><a href="#BaseSettings.on_shutdown-60"><span class="linenos">60</span></a>    <span class="nd">@staticmethod</span>
+
+                            </div>
+                            <div id="BaseSettings.on_shutdown" class="classattr">
+                                        <input id="BaseSettings.on_shutdown-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+                    <div class="decorator">@staticmethod</div>
+
+        <span class="def">async def</span>
+        <span class="name">on_shutdown</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">ctx</span><span class="p">:</span> <span class="n">Dict</span><span class="p">[</span><span class="n">Any</span><span class="p">,</span> <span class="n">Any</span><span class="p">]</span></span><span class="return-annotation">) -> <span class="kc">None</span>:</span></span>
+
+                <label class="view-source-button" for="BaseSettings.on_shutdown-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#BaseSettings.on_shutdown"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="BaseSettings.on_shutdown-60"><a href="#BaseSettings.on_shutdown-60"><span class="linenos">60</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="BaseSettings.on_shutdown-61"><a href="#BaseSettings.on_shutdown-61"><span class="linenos">61</span></a>    <span class="k">async</span> <span class="k">def</span> <span class="nf">on_shutdown</span><span class="p">(</span><span class="n">ctx</span><span class="p">:</span> <span class="n">Context</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="kc">None</span><span class="p">:</span>
 </span><span id="BaseSettings.on_shutdown-62"><a href="#BaseSettings.on_shutdown-62"><span class="linenos">62</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="BaseSettings.on_shutdown-63"><a href="#BaseSettings.on_shutdown-63"><span class="linenos">63</span></a><span class="sd">        Gracefully shuts down the available thread and process pool executors.</span>
@@ -2057,47 +593,27 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="BaseSettings.on_shutdown-69"><a href="#BaseSettings.on_shutdown-69"><span class="linenos">69</span></a>
 </span><span id="BaseSettings.on_shutdown-70"><a href="#BaseSettings.on_shutdown-70"><span class="linenos">70</span></a>        <span class="k">with</span> <span class="n">styled_text</span><span class="p">(</span><span class="n">Fore</span><span class="o">.</span><span class="n">BLUE</span><span class="p">,</span> <span class="n">Style</span><span class="o">.</span><span class="n">DIM</span><span class="p">):</span>
 </span><span id="BaseSettings.on_shutdown-71"><a href="#BaseSettings.on_shutdown-71"><span class="linenos">71</span></a>            <span class="nb">print</span><span class="p">(</span><span class="s2">&quot;[justjobs] Gracefully shutdown executors ✔&quot;</span><span class="p">)</span>
-</span></pre>
-          </div>
+</span></pre></div>
 
-          <div class="docstring">
-            <p>
-              Gracefully shuts down the available thread and process pool
-              executors.
-            </p>
-          </div>
-        </div>
-        <div id="BaseSettings.job_serializer" class="classattr">
-          <input
-            id="BaseSettings.job_serializer-view-source"
-            class="view-source-toggle-state"
-            type="checkbox"
-            aria-hidden="true"
-            tabindex="-1"
-          />
-          <div class="attr function">
-            <div class="decorator">@staticmethod</div>
 
-            <span class="def">def</span>
-            <span class="name">job_serializer</span
-            ><span class="signature pdoc-code condensed"
-              >(<span class="param"
-                ><span class="n">job</span><span class="p">:</span>
-                <span class="n">Any</span></span
-              ><span class="return-annotation"
-                >) -> <span class="nb">bytes</span>:</span
-              ></span
-            >
+            <div class="docstring"><p>Gracefully shuts down the available thread and process pool executors.</p>
+</div>
 
-            <label
-              class="view-source-button"
-              for="BaseSettings.job_serializer-view-source"
-              ><span>View Source</span></label
-            >
-          </div>
-          <a class="headerlink" href="#BaseSettings.job_serializer"></a>
-          <div class="pdoc-code codehilite">
-            <pre><span></span><span id="BaseSettings.job_serializer-73"><a href="#BaseSettings.job_serializer-73"><span class="linenos">73</span></a>    <span class="nd">@staticmethod</span>
+
+                            </div>
+                            <div id="BaseSettings.job_serializer" class="classattr">
+                                        <input id="BaseSettings.job_serializer-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+                    <div class="decorator">@staticmethod</div>
+
+        <span class="def">def</span>
+        <span class="name">job_serializer</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">job</span><span class="p">:</span> <span class="n">Any</span></span><span class="return-annotation">) -> <span class="nb">bytes</span>:</span></span>
+
+                <label class="view-source-button" for="BaseSettings.job_serializer-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#BaseSettings.job_serializer"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="BaseSettings.job_serializer-73"><a href="#BaseSettings.job_serializer-73"><span class="linenos">73</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="BaseSettings.job_serializer-74"><a href="#BaseSettings.job_serializer-74"><span class="linenos">74</span></a>    <span class="k">def</span> <span class="nf">job_serializer</span><span class="p">(</span><span class="n">job</span><span class="p">:</span> <span class="n">Any</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bytes</span><span class="p">:</span>
 </span><span id="BaseSettings.job_serializer-75"><a href="#BaseSettings.job_serializer-75"><span class="linenos">75</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="BaseSettings.job_serializer-76"><a href="#BaseSettings.job_serializer-76"><span class="linenos">76</span></a><span class="sd">        Serializes the given job using dill and signs it using blake2b. The serialized</span>
@@ -2109,48 +625,28 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="BaseSettings.job_serializer-82"><a href="#BaseSettings.job_serializer-82"><span class="linenos">82</span></a>        <span class="c1"># must be hexdigest to ensure no premature byte delimiters</span>
 </span><span id="BaseSettings.job_serializer-83"><a href="#BaseSettings.job_serializer-83"><span class="linenos">83</span></a>        <span class="n">sig</span> <span class="o">=</span> <span class="n">signer</span><span class="o">.</span><span class="n">hexdigest</span><span class="p">()</span>
 </span><span id="BaseSettings.job_serializer-84"><a href="#BaseSettings.job_serializer-84"><span class="linenos">84</span></a>        <span class="k">return</span> <span class="p">(</span><span class="n">sig</span> <span class="o">+</span> <span class="s2">&quot;|&quot;</span><span class="p">)</span><span class="o">.</span><span class="n">encode</span><span class="p">(</span><span class="s2">&quot;utf-8&quot;</span><span class="p">)</span> <span class="o">+</span> <span class="n">serialized</span>
-</span></pre>
-          </div>
+</span></pre></div>
 
-          <div class="docstring">
-            <p>
-              Serializes the given job using dill and signs it using blake2b.
-              The serialized job and its signature are returned for later
-              verification.
-            </p>
-          </div>
-        </div>
-        <div id="BaseSettings.job_deserializer" class="classattr">
-          <input
-            id="BaseSettings.job_deserializer-view-source"
-            class="view-source-toggle-state"
-            type="checkbox"
-            aria-hidden="true"
-            tabindex="-1"
-          />
-          <div class="attr function">
-            <div class="decorator">@staticmethod</div>
 
-            <span class="def">def</span>
-            <span class="name">job_deserializer</span
-            ><span class="signature pdoc-code condensed"
-              >(<span class="param"
-                ><span class="n">packed</span><span class="p">:</span>
-                <span class="nb">bytes</span></span
-              ><span class="return-annotation"
-                >) -> <span class="n">Any</span>:</span
-              ></span
-            >
+            <div class="docstring"><p>Serializes the given job using dill and signs it using blake2b. The serialized
+job and its signature are returned for later verification.</p>
+</div>
 
-            <label
-              class="view-source-button"
-              for="BaseSettings.job_deserializer-view-source"
-              ><span>View Source</span></label
-            >
-          </div>
-          <a class="headerlink" href="#BaseSettings.job_deserializer"></a>
-          <div class="pdoc-code codehilite">
-            <pre><span></span><span id="BaseSettings.job_deserializer-86"><a href="#BaseSettings.job_deserializer-86"><span class="linenos"> 86</span></a>    <span class="nd">@staticmethod</span>
+
+                            </div>
+                            <div id="BaseSettings.job_deserializer" class="classattr">
+                                        <input id="BaseSettings.job_deserializer-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+                    <div class="decorator">@staticmethod</div>
+
+        <span class="def">def</span>
+        <span class="name">job_deserializer</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">packed</span><span class="p">:</span> <span class="nb">bytes</span></span><span class="return-annotation">) -> <span class="n">Any</span>:</span></span>
+
+                <label class="view-source-button" for="BaseSettings.job_deserializer-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#BaseSettings.job_deserializer"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="BaseSettings.job_deserializer-86"><a href="#BaseSettings.job_deserializer-86"><span class="linenos"> 86</span></a>    <span class="nd">@staticmethod</span>
 </span><span id="BaseSettings.job_deserializer-87"><a href="#BaseSettings.job_deserializer-87"><span class="linenos"> 87</span></a>    <span class="k">def</span> <span class="nf">job_deserializer</span><span class="p">(</span><span class="n">packed</span><span class="p">:</span> <span class="nb">bytes</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Any</span><span class="p">:</span>
 </span><span id="BaseSettings.job_deserializer-88"><a href="#BaseSettings.job_deserializer-88"><span class="linenos"> 88</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="BaseSettings.job_deserializer-89"><a href="#BaseSettings.job_deserializer-89"><span class="linenos"> 89</span></a><span class="sd">        Extracts the signature from the serialized job and compares it with the job</span>
@@ -2167,49 +663,28 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="BaseSettings.job_deserializer-100"><a href="#BaseSettings.job_deserializer-100"><span class="linenos">100</span></a>            <span class="p">)</span>
 </span><span id="BaseSettings.job_deserializer-101"><a href="#BaseSettings.job_deserializer-101"><span class="linenos">101</span></a>
 </span><span id="BaseSettings.job_deserializer-102"><a href="#BaseSettings.job_deserializer-102"><span class="linenos">102</span></a>        <span class="k">return</span> <span class="n">dill</span><span class="o">.</span><span class="n">loads</span><span class="p">(</span><span class="n">serialized</span><span class="p">)</span>
-</span></pre>
-          </div>
+</span></pre></div>
 
-          <div class="docstring">
-            <p>
-              Extracts the signature from the serialized job and compares it
-              with the job function. If the signatures match, the job is
-              deserialized and executed. If not, an error is raised.
-            </p>
-          </div>
-        </div>
-        <div id="BaseSettings.create_pool" class="classattr">
-          <input
-            id="BaseSettings.create_pool-view-source"
-            class="view-source-toggle-state"
-            type="checkbox"
-            aria-hidden="true"
-            tabindex="-1"
-          />
-          <div class="attr function">
-            <span class="def">def</span>
-            <span class="name">create_pool</span
-            ><span class="signature pdoc-code condensed"
-              >(<span class="param"><span class="bp">cls</span>, </span
-              ><span class="param"
-                ><span class="o">**</span><span class="n">kwargs</span
-                ><span class="p">:</span> <span class="n">Any</span></span
-              ><span class="return-annotation"
-                >) -> <span class="n">just_jobs</span><span class="o">.</span
-                ><span class="n">broker</span><span class="o">.</span
-                ><span class="n">Broker</span>:</span
-              ></span
-            >
 
-            <label
-              class="view-source-button"
-              for="BaseSettings.create_pool-view-source"
-              ><span>View Source</span></label
-            >
-          </div>
-          <a class="headerlink" href="#BaseSettings.create_pool"></a>
-          <div class="pdoc-code codehilite">
-            <pre><span></span><span id="BaseSettings.create_pool-104"><a href="#BaseSettings.create_pool-104"><span class="linenos">104</span></a>    <span class="k">def</span> <span class="nf">create_pool</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">:</span> <span class="n">Any</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Broker</span><span class="p">:</span>
+            <div class="docstring"><p>Extracts the signature from the serialized job and compares it with the job
+function. If the signatures match, the job is deserialized and executed. If
+not, an error is raised.</p>
+</div>
+
+
+                            </div>
+                            <div id="BaseSettings.create_pool" class="classattr">
+                                        <input id="BaseSettings.create_pool-view-source" class="view-source-toggle-state" type="checkbox" aria-hidden="true" tabindex="-1">
+<div class="attr function">
+            
+        <span class="def">def</span>
+        <span class="name">create_pool</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">cls</span>, </span><span class="param"><span class="o">**</span><span class="n">kwargs</span><span class="p">:</span> <span class="n">Any</span></span><span class="return-annotation">) -> <span class="n">just_jobs</span><span class="o">.</span><span class="n">broker</span><span class="o">.</span><span class="n">Broker</span>:</span></span>
+
+                <label class="view-source-button" for="BaseSettings.create_pool-view-source"><span>View Source</span></label>
+
+    </div>
+    <a class="headerlink" href="#BaseSettings.create_pool"></a>
+            <div class="pdoc-code codehilite"><pre><span></span><span id="BaseSettings.create_pool-104"><a href="#BaseSettings.create_pool-104"><span class="linenos">104</span></a>    <span class="k">def</span> <span class="nf">create_pool</span><span class="p">(</span><span class="bp">cls</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">:</span> <span class="n">Any</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">Broker</span><span class="p">:</span>
 </span><span id="BaseSettings.create_pool-105"><a href="#BaseSettings.create_pool-105"><span class="linenos">105</span></a><span class="w">        </span><span class="sd">&quot;&quot;&quot;</span>
 </span><span id="BaseSettings.create_pool-106"><a href="#BaseSettings.create_pool-106"><span class="linenos">106</span></a><span class="sd">        Creates an ArqRedis instance using this class&#39; RedisSettings and job</span>
 </span><span id="BaseSettings.create_pool-107"><a href="#BaseSettings.create_pool-107"><span class="linenos">107</span></a><span class="sd">        serializers. This function technically returns an instance of Broker,</span>
@@ -2228,36 +703,40 @@ $<span class="w"> </span>pip<span class="w"> </span>install<span class="w"> </sp
 </span><span id="BaseSettings.create_pool-120"><a href="#BaseSettings.create_pool-120"><span class="linenos">120</span></a>            <span class="n">unpackj</span><span class="o">=</span><span class="bp">cls</span><span class="o">.</span><span class="n">job_deserializer</span><span class="p">,</span>
 </span><span id="BaseSettings.create_pool-121"><a href="#BaseSettings.create_pool-121"><span class="linenos">121</span></a>            <span class="n">kwargs</span><span class="o">=</span><span class="n">kwargs</span><span class="p">,</span>
 </span><span id="BaseSettings.create_pool-122"><a href="#BaseSettings.create_pool-122"><span class="linenos">122</span></a>        <span class="p">)</span>
-</span></pre>
-          </div>
+</span></pre></div>
 
-          <div class="docstring">
-            <p>
-              Creates an ArqRedis instance using this class' RedisSettings and
-              job serializers. This function technically returns an instance of
-              Broker, so the pool creation is delayed until the returned object
-              is either awaited or entered.
-            </p>
-          </div>
-        </div>
-        <div class="inherited">
-          <h5>Inherited Members</h5>
-          <dl>
-            <div>
-              <dt>builtins.type</dt>
-              <dd id="BaseSettings.__init__" class="function">type</dd>
-              <dd id="BaseSettings.mro" class="function">mro</dd>
+
+            <div class="docstring"><p>Creates an ArqRedis instance using this class' RedisSettings and job
+serializers. This function technically returns an instance of Broker,
+so the pool creation is delayed until the returned object is either
+awaited or entered.</p>
+</div>
+
+
+                            </div>
+                            <div class="inherited">
+                                <h5>Inherited Members</h5>
+                                <dl>
+                                    <div><dt>builtins.type</dt>
+                                <dd id="BaseSettings.__init__" class="function">type</dd>
+                <dd id="BaseSettings.mro" class="function">mro</dd>
+
             </div>
-          </dl>
-        </div>
-      </section>
-      <section id="Context">
-        <div class="attr variable">
-          <span class="name">Context</span> =
-          <span class="default_value">typing.Dict[typing.Any, typing.Any]</span>
-        </div>
-        <a class="headerlink" href="#Context"></a>
-      </section>
+                                </dl>
+                            </div>
+                </section>
+                <section id="Context">
+                    <div class="attr variable">
+            <span class="name">Context</span>        =
+<span class="default_value">typing.Dict[typing.Any, typing.Any]</span>
+
+        
+    </div>
+    <a class="headerlink" href="#Context"></a>
+    
+    
+
+                </section>
     </main>
-  </body>
+</body>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "just-jobs"
 description = "A friendly and lightweight wrapper for arq."
-version = "2.0.0"
+version = "2.1.0"
 authors = [
     {name = "Elias Gabriel", email = "me@eliasfgabriel.com"},
 ]
@@ -17,11 +17,10 @@ dependencies = [
 ]
 
 [project.urls]
-repository = "https://github.com/thearchitector/just-jobs"
+homepage = "https://justjobs.thearchitector.dev"
 documentation = "https://justjobs.thearchitector.dev"
-
-[tool.pdm.build]
-includes = ["just_jobs/py.typed", "CHANGELOG.md"]
+changelog = "https://github.com/thearchitector/just-jobs/blob/main/CHANGELOG.md"
+repository = "https://github.com/thearchitector/just-jobs"
 
 [tool.pdm.scripts]
 docs = "pdoc -o docs --no-search just_jobs"

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -39,13 +39,26 @@ def async_cpu_task(ctx: Context, val: str):
 
 @pytest.mark.parametrize("func", [async_task, cpu_task, io_task, async_cpu_task])
 async def test_invoke_now(func):
-    res = await func.now(" on ")
+    with pytest.deprecated_call():
+        res = await func.now(" on ")
+        assert res == f"{getpid()} on {get_ident()}"
+
+
+@pytest.mark.parametrize("func", [async_task, async_cpu_task])
+async def test_invoke_async_now(func):
+    res = await func(" on ")
+    assert res == f"{getpid()} on {get_ident()}"
+
+
+@pytest.mark.parametrize("func", [cpu_task, io_task])
+async def test_invoke_sync_now(func):
+    res = func(" on ")
     assert res == f"{getpid()} on {get_ident()}"
 
 
 async def test_failing_now():
     with pytest.raises(Exception, match="mock"):
-        await failing_task.now()
+        await failing_task()
 
 
 async def test_enqueue_job_async(enqueue_run_job):


### PR DESCRIPTION
### Changed

- Deprecated `.now` in favor of direct calling to make things cleaner and more inline with the "jobs are just normal functions" philosophy.

```python
# from
await async_func.now("hello")
await sync_func.now("world")

# to
await async_func("hello")
sync_func("world")
```